### PR TITLE
Utils::getArity fails on callables in array format

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -41,6 +41,12 @@ abstract class Utils
             return 0;
         }
 
+        if (is_array($callable)) {
+            list($class, $method) = $callable;
+            $r = new ReflectionMethod($class, $method);
+            return $r->getNumberOfRequiredParameters();
+        }
+
         $r = new ReflectionFunction($callable);
         return $r->getNumberOfRequiredParameters();
     }

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -13,6 +13,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Stratigility\Dispatch;
 use Zend\Stratigility\MiddlewarePipe;
 use Zend\Stratigility\Utils;
+use ZendTest\Stratigility\TestAsset\NormalHandler;
 
 class UtilsTest extends TestCase
 {
@@ -24,6 +25,7 @@ class UtilsTest extends TestCase
             }, 2],
             'invokable' => [new Dispatch(), 5],
             'interface' => [new MiddlewarePipe(), 2], // 2 REQUIRED arguments!
+            'callable'  => [array(new NormalHandler(), 'handle'), 3]
         ];
     }
 

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -25,7 +25,7 @@ class UtilsTest extends TestCase
             }, 2],
             'invokable' => [new Dispatch(), 5],
             'interface' => [new MiddlewarePipe(), 2], // 2 REQUIRED arguments!
-            'callable'  => [array(new NormalHandler(), 'handle'), 3]
+            'callable'  => [[new NormalHandler(), 'handle'], 3]
         ];
     }
 


### PR DESCRIPTION
This patch allows Utils::getArity to correctly return the arity on callables passed in array format

i.e.

```php
array($this, 'method')
array('SomeClass', 'someMethod')
```