### PR TITLE
Update Utils.php

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -32,7 +32,7 @@ abstract class Utils
                 }
 
                 $r = new ReflectionMethod($callable, $method);
-                return $r->getNumberOfRequiredParameters();
+                return $r->getNumberOfParameters();
             }
             return 0;
         }

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -25,7 +25,7 @@ class UtilsTest extends TestCase
             'closure'        => [function ($x, $y) {
             }, 2],
             'invokable'      => [new Dispatch(), 5],
-            'interface'      => [new MiddlewarePipe(), 2], // 2 REQUIRED arguments!
+            'interface'      => [new MiddlewarePipe(), 3], // 3 OPTIONAL arguments!
             'callable'       => [[new NormalHandler(), 'handle'], 3],
             'static-method'  => [[__NAMESPACE__ . '\TestAsset\StaticHandler', 'handle'], 3],
             'static-access'  => [__NAMESPACE__ . '\TestAsset\StaticHandler::handle', 3],


### PR DESCRIPTION
If $out/$next is nullable then `getNumberOfRequiredParameters()` will return 3 for a valid error handler with a null $out/$next causing the error detection to fail unless you use the ErrorMiddlewareInterface.

I think it's intended to use `getNumberOfParameters()` here.

**EDIT** There's a few other places in that file that would need changed but I'll wait until I hear back from you.