### PR TITLE
Next should clone $queue for long-lived scripts

### DIFF
--- a/src/Next.php
+++ b/src/Next.php
@@ -40,12 +40,16 @@ class Next
     private $removed = '';
 
     /**
+     * Constructor.
+     *
+     * Clones the queue provided to allow re-use.
+     *
      * @param SplQueue $queue
      * @param callable $done
      */
     public function __construct(SplQueue $queue, callable $done)
     {
-        $this->queue    = $queue;
+        $this->queue    = clone $queue;
         $this->done     = $done;
 
         $this->dispatch = new Dispatch();

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Stratigility;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
 use SplQueue;
 use Zend\Diactoros\ServerRequest as PsrRequest;
 use Zend\Diactoros\Response as PsrResponse;
@@ -305,5 +306,24 @@ class NextTest extends TestCase
         $next    = new Next($this->queue, $done);
         $result  = $next($request, $this->response);
         $this->assertSame($this->response, $result);
+    }
+
+    /**
+     * @group 25
+     */
+    public function testNextShouldCloneQueueOnInstantiation()
+    {
+        $phpunit = $this;
+        $done = function ($req, $res, $err) use ($phpunit) {
+            $phpunit->fail('Should not hit final handler');
+        };
+        $next = new Next($this->queue, $done);
+
+        $r = new ReflectionProperty($next, 'queue');
+        $r->setAccessible(true);
+        $queue = $r->getValue($next);
+
+        $this->assertNotSame($this->queue, $queue);
+        $this->assertEquals($this->queue, $queue);
     }
 }


### PR DESCRIPTION
https://github.com/zendframework/zend-stratigility/blob/716c647fb76303c76c0c254bb4c5bc628aefa7e1/src/Next.php#L48

$queue should be cloned so that long-lived scripts can function. Without cloning the pipe will only ever work the first time and the queue will be empty on the next iteration.