### PR TITLE
Allow PSR-7 messages to Dispatch

### DIFF
--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -10,6 +10,8 @@
 namespace Zend\Stratigility;
 
 use Exception;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Dispatch middleware
@@ -42,15 +44,15 @@ class Dispatch
      *
      * @param Route $route
      * @param mixed $err
-     * @param Http\Request $request
-     * @param Http\Response $response
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      * @param callable $next
      */
     public function __invoke(
         Route $route,
         $err,
-        Http\Request $request,
-        Http\Response $response,
+        ServerRequestInterface $request,
+        ResponseInterface $response,
         callable $next
     ) {
         $handler  = $route->handler;


### PR DESCRIPTION
`Next` allows any PSR-7 implementations. However, prior to this patch, `Dispatch` required the Stratigilty-specific decorators, which could result in issues if `$next()` was invoked with non-Stratigility instances:

```php
return $next($request, new JsonResponse());
```

This patch adds a test to ensure that `Dispatch` will pass them through properly, and modifies the typehints to use the PSR-7 interfaces. The change is completely BC, as the Stratigility implementations are a superset of PSR-7, and no specfic functionality from them was used previously.

Fixes #28.