### PR TITLE
Minor optimization

### DIFF
--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -74,11 +74,11 @@ class Dispatch
 
         try {
             if ($hasError && $arity === 4) {
-                return call_user_func($handler, $err, $request, $response, $next);
+                return $handler($err, $request, $response, $next);
             }
 
             if (! $hasError && $arity < 4) {
-                return call_user_func($handler, $request, $response, $next);
+                return $handler($request, $response, $next);
             }
         } catch (Exception $e) {
             $err = $e;


### PR DESCRIPTION
This change prevents the usage of the slow call_user_func. The tests run on my machine but I didn't remember if this mechanism was not added on PHP 5.5 or 5.6... so I decided to do the PR and see if it passes on all PHP versions :).