### PR TITLE
Finalhandler production stacktrace fix

### DIFF
--- a/src/FinalHandler.php
+++ b/src/FinalHandler.php
@@ -121,7 +121,8 @@ class FinalHandler
     private function handleError($error, RequestInterface $request, ResponseInterface $response)
     {
         $response = $response->withStatus(
-            Utils::getStatusCode($error, $response)
+            Utils::getStatusCode($error, $response),
+            $response->getReasonPhrase()
         );
 
         $message = $response->getReasonPhrase() ?: 'Unknown Error';

--- a/src/FinalHandler.php
+++ b/src/FinalHandler.php
@@ -114,9 +114,7 @@ class FinalHandler
         );
 
         $message = $response->getReasonPhrase() ?: 'Unknown Error';
-        if (! isset($this->options['env'])
-            || $this->options['env'] !== 'production'
-        ) {
+        if (isset($this->options['env']) && $this->options['env'] !== 'production') {
             $message = $this->createDevelopmentErrorMessage($error);
         }
 

--- a/src/FinalHandler.php
+++ b/src/FinalHandler.php
@@ -44,12 +44,9 @@ class FinalHandler
      */
     public function __construct(array $options = [], ResponseInterface $response = null)
     {
-        $this->options  = $options;
-        $this->response = $response;
+        $this->options = $options;
 
-        if ($response) {
-            $this->bodySize = $response->getBody()->getSize();
-        }
+        $this->setOriginalResponse($response);
     }
 
     /**
@@ -95,6 +92,20 @@ class FinalHandler
         }
 
         return $this->create404($request, $response);
+    }
+
+    /**
+     * Set the original response and response body size for comparison.
+     *
+     * @param ResponseInterface $response
+     */
+    public function setOriginalResponse(ResponseInterface $response = null)
+    {
+        $this->response = $response;
+
+        if ($response) {
+            $this->bodySize = $response->getBody()->getSize();
+        }
     }
 
     /**

--- a/test/FinalHandlerTest.php
+++ b/test/FinalHandlerTest.php
@@ -176,4 +176,19 @@ class FinalHandlerTest extends TestCase
         $result = $final(new Request(new PsrRequest()), $response);
         $this->assertSame($response, $result);
     }
+
+    public function testCanReplaceOriginalResponseAndBodySizeAfterConstruction()
+    {
+        $psrResponse = new PsrResponse();
+        $originalResponse = new Response(new PsrResponse());
+        $originalResponse->write('foo');
+
+        $final = new FinalHandler([], $psrResponse);
+        $final->setOriginalResponse($originalResponse);
+
+        /** @var Response $actualResponse */
+        $actualResponse = self::readAttribute($final, 'response');
+        $this->assertSame($originalResponse, $actualResponse);
+        $this->assertSame(3, $actualResponse->getBody()->getSize());
+    }
 }

--- a/test/FinalHandlerTest.php
+++ b/test/FinalHandlerTest.php
@@ -54,6 +54,7 @@ class FinalHandlerTest extends TestCase
     public function testInvokingWithErrorInNonProductionModeSetsResponseBodyToError()
     {
         $error    = 'error';
+        $this->final = new FinalHandler(['env' => 'not-production']);
         $response = call_user_func($this->final, $this->request, $this->response, $error);
         $this->assertEquals($error, (string) $response->getBody());
     }
@@ -61,6 +62,7 @@ class FinalHandlerTest extends TestCase
     public function testInvokingWithExceptionInNonProductionModeIncludesExceptionMessageInResponseBody()
     {
         $error    = new Exception('foo', 400);
+        $this->final = new FinalHandler(['env' => 'not-production']);
         $response = call_user_func($this->final, $this->request, $this->response, $error);
         $expected = $this->escaper->escapeHtml($error->getMessage());
         $this->assertContains($expected, (string) $response->getBody());
@@ -69,9 +71,33 @@ class FinalHandlerTest extends TestCase
     public function testInvokingWithExceptionInNonProductionModeIncludesTraceInResponseBody()
     {
         $error    = new Exception('foo', 400);
+        $this->final = new FinalHandler(['env' => 'not-production']);
         $response = call_user_func($this->final, $this->request, $this->response, $error);
         $expected = $this->escaper->escapeHtml($error->getTraceAsString());
         $this->assertContains($expected, (string) $response->getBody());
+    }
+
+    public function testInvokingWithErrorAndNoEnvironmentModeSetDoesNotSetResponseBodyToError()
+    {
+        $error    = 'error';
+        $response = call_user_func($this->final, $this->request, $this->response, $error);
+        $this->assertNotEquals($error, (string) $response->getBody());
+    }
+
+    public function testInvokingWithExceptionAndNoEnvironmentModeSetDoesNotIncludeExceptionMessageInResponseBody()
+    {
+        $error    = new Exception('foo', 400);
+        $response = call_user_func($this->final, $this->request, $this->response, $error);
+        $expected = $this->escaper->escapeHtml($error->getMessage());
+        $this->assertNotContains($expected, (string) $response->getBody());
+    }
+
+    public function testInvokingWithExceptionAndNoEnvironmentModeSetDoesNotIncludeTraceInResponseBody()
+    {
+        $error    = new Exception('foo', 400);
+        $response = call_user_func($this->final, $this->request, $this->response, $error);
+        $expected = $this->escaper->escapeHtml($error->getTraceAsString());
+        $this->assertNotContains($expected, (string) $response->getBody());
     }
 
     public function testInvokingWithErrorInProductionSetsResponseToReasonPhrase()

--- a/test/FinalHandlerTest.php
+++ b/test/FinalHandlerTest.php
@@ -136,6 +136,13 @@ class FinalHandlerTest extends TestCase
         $this->assertEquals(404, $response->getStatusCode());
     }
 
+    public function testErrorResponsePreservesOriginalReasonPhraseIfSet()
+    {
+        $this->response = $this->response->withStatus(500, 'It broke!');
+        $response = call_user_func($this->final, $this->request, $this->response, new \Exception('foo'));
+        $this->assertSame($this->response->getReasonPhrase(), $response->getReasonPhrase());
+    }
+
     public function test404ResponseIncludesOriginalRequestUri()
     {
         $originalUrl = 'http://local.example.com/bar/foo';


### PR DESCRIPTION
@weierophinney this addresses #45 and makes it possible to create the `FinalHandler` in a factory and worry about the original response later.

One thing I wasn't sure about was whether error details should be in the case of `'env' !== 'production'` vs. `'env' === 'development'`. Production is surely "NO" and development is surely "YES", but other environments like staging, qa, etc. may depend on the implementor. Perhaps a boolean `display_error_details` option would be better than `env`? If so, what would you do with the original `env`? Remove it completely? Or automatically set `display_error_details` to `true` if `env != production` and `false` otherwise for BC?