### PR TITLE
Fix typehint return on Response decorator

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -56,6 +56,7 @@ class Response implements
      * Proxies to the underlying stream and writes the provided data to it.
      *
      * @param string $data
+     * @return self
      */
     public function write($data)
     {
@@ -77,6 +78,7 @@ class Response implements
      * prior to marking the response as complete.
      *
      * @param string $data
+     * @return self
      */
     public function end($data = null)
     {


### PR DESCRIPTION
Only to correct a missing @return tag in method.
