### PR TITLE
Hotfix - #37 - catch also php 7 throwables

### DIFF
--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -10,6 +10,7 @@
 namespace Zend\Stratigility;
 
 use Exception;
+use Throwable;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -80,6 +81,8 @@ class Dispatch
             if (! $hasError && $arity < 4) {
                 return call_user_func($handler, $request, $response, $next);
             }
+        } catch (Throwable $t) {
+            $err = $t;
         } catch (Exception $e) {
             $err = $e;
         }

--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -81,10 +81,10 @@ class Dispatch
             if (! $hasError && $arity < 4) {
                 return call_user_func($handler, $request, $response, $next);
             }
-        } catch (Throwable $t) {
-            $err = $t;
-        } catch (Exception $e) {
-            $err = $e;
+        } catch (Throwable $throwable) {
+            return $next($request, $response, $throwable);
+        } catch (Exception $exception) {
+            return $next($request, $response, $exception);
         }
 
         return $next($request, $response, $err);

--- a/test/DispatchTest.php
+++ b/test/DispatchTest.php
@@ -18,6 +18,16 @@ use Zend\Stratigility\Route;
 
 class DispatchTest extends TestCase
 {
+    /**
+     * @var \Zend\Stratigility\Http\Request|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $request;
+
+    /**
+     * @var \Zend\Stratigility\Http\Response|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $response;
+
     public function setUp()
     {
         $this->request  = $this->getMockBuilder('Zend\Stratigility\Http\Request')
@@ -198,5 +208,48 @@ class DispatchTest extends TestCase
         $err      = null;
         $result = $dispatch($route, $err, $request->reveal(), $response->reveal(), $next);
         $this->assertSame($response->reveal(), $result);
+    }
+
+    /**
+     * @requires PHP 7.0
+     * @group 37
+     */
+    public function testWillCatchPhp7Throwable()
+    {
+        $callableWithHint = function (\stdClass $parameter) {
+            // will not be executed
+        };
+
+        $middleware = function ($req, $res, $next) use ($callableWithHint) {
+            $callableWithHint('not an stdClass');
+        };
+
+        $errorHandler = $this->getMock('stdClass', ['__invoke']);
+        $errorHandler
+            ->expects(self::once())
+            ->method('__invoke')
+            ->with(
+                $this->request,
+                $this->response,
+                self::callback(function (\TypeError $throwable) {
+                    self::assertStringStartsWith(
+                        'Argument 1 passed to ZendTest\Stratigility\DispatchTest::ZendTest\Stratigility\{closure}()'
+                        . ' must be an instance of stdClass, string given',
+                        $throwable->getMessage()
+                    );
+
+                    return true;
+                })
+            );
+
+        $dispatch = new Dispatch();
+
+        $dispatch(
+            new Route('/foo', $middleware),
+            null,
+            $this->request,
+            $this->response,
+            $errorHandler
+        );
     }
 }


### PR DESCRIPTION
Provides tests for #37