### PR TITLE
[BUG FIX] "500 OK" error responses

### DIFF
--- a/src/FinalHandler.php
+++ b/src/FinalHandler.php
@@ -120,12 +120,13 @@ class FinalHandler
      */
     private function handleError($error, RequestInterface $request, ResponseInterface $response)
     {
-        $response = $response->withStatus(
-            Utils::getStatusCode($error, $response),
-            $response->getReasonPhrase()
-        );
-
+        $statusCode = Utils::getStatusCode($error, $response);
+        $reasonPhrase = $response->getStatusCode() === $statusCode
+                      ? $response->getReasonPhrase()
+                      : '';
+        $response = $response->withStatus($statusCode, $reasonPhrase);
         $message = $response->getReasonPhrase() ?: 'Unknown Error';
+
         if (isset($this->options['env']) && $this->options['env'] !== 'production') {
             $message = $this->createDevelopmentErrorMessage($error);
         }


### PR DESCRIPTION
This addresses the issue reported in #51.

#46 ensured that response reason phrases set by developers would be preserved when building error responses. Unfortunately, it also ensured that reason phrases _NOT_ set by developers (i.e., "OK") would also be preserved.

This PR takes the following use cases into account. Let me know if I missed a possibility!

1. **All is well and an exception is thrown:** Error response will have the status code corresponding to the code of the exception that was thrown (or 500 by default). Error response reason phrase will be whatever the HTTP standard is for the code that was chosen.
2. **Response is already in an error state, then an exception is thrown**, which means either:
    1. The application caught an exception, updated the response, then threw the same exception. If that's the case, then we assume the reason phrase was also updated, and we keep it.
    2. The application encountered an error, updated the response, and then _something else_ happened before getting to the `FinalHandler` (maybe another middleware in the error middleware pipeline does some kind of logging or external error reporting, and that failed). In this case, the reason phrase will be preserved if the resulting exception doesn't change the status code. If it does, then there will be a new reason phrase. _**I expect this should be a rare occurrence**_, but at least there is a sane default behavior when it happens.