### PR TITLE
Do not mark response as complete in FinalHandler

### DIFF
--- a/src/FinalHandler.php
+++ b/src/FinalHandler.php
@@ -251,10 +251,10 @@ class FinalHandler
     private function completeResponse(ResponseInterface $response, $message)
     {
         if ($response instanceof Http\Response) {
-            return $response->end($message);
+            return $response->write($message);
         }
 
         $response = new Http\Response($response);
-        return $response->end($message);
+        return $response->write($message);
     }
 }

--- a/test/FinalHandlerTest.php
+++ b/test/FinalHandlerTest.php
@@ -246,7 +246,7 @@ class FinalHandlerTest extends TestCase
     {
         $error = new Exception('Exception message', 501);
 
-        $response = $this->prophesize(Response::class);
+        $response = $this->prophesize('Zend\Stratigility\Http\Response');
         $response->getStatusCode()->willReturn(200);
         $response->withStatus(501, '')->will(function () use ($response) {
             return $response->reveal();
@@ -258,7 +258,7 @@ class FinalHandlerTest extends TestCase
 
         $final = new FinalHandler([], new Response(new PsrResponse()));
         $this->assertSame($response->reveal(), $final(
-            $this->prophesize(Request::class)->reveal(),
+            $this->prophesize('Zend\Stratigility\Http\Request')->reveal(),
             $response->reveal(),
             $error
         ));
@@ -276,12 +276,12 @@ class FinalHandlerTest extends TestCase
 
         $final = new FinalHandler([], new Response(new PsrResponse()));
         $test = $final(
-            $this->prophesize(Request::class)->reveal(),
+            $this->prophesize('Zend\Stratigility\Http\Request')->reveal(),
             $response,
             $error
         );
 
-        $this->assertInstanceOf(Response::class, $test);
+        $this->assertInstanceOf('Zend\Stratigility\Http\Response', $test);
         $this->assertSame(501, $test->getStatusCode());
         $this->assertSame('Not Implemented', $test->getReasonPhrase());
 
@@ -295,10 +295,10 @@ class FinalHandlerTest extends TestCase
      */
     public function testShouldNotMarkStratigilityResponseAsCompleteWhenCreating404s()
     {
-        $body     = $this->prophesize(StreamInterface::class);
+        $body     = $this->prophesize('Psr\Http\Message\StreamInterface');
         $body->getSize()->willReturn(0)->shouldBeCalledTimes(2);
 
-        $response = $this->prophesize(Response::class);
+        $response = $this->prophesize('Zend\Stratigility\Http\Response');
         $response->getBody()->will(function () use ($body) {
             return $body->reveal();
         });
@@ -312,7 +312,7 @@ class FinalHandlerTest extends TestCase
             })
             ->shouldBeCalled();
 
-        $request = $this->prophesize(PsrRequest::class);
+        $request = $this->prophesize('Zend\Diactoros\ServerRequest');
         $request->getUri()->willReturn('/foo');
         $request->getMethod()->willReturn('GET');
 
@@ -330,7 +330,7 @@ class FinalHandlerTest extends TestCase
     {
         $response = new PsrResponse();
 
-        $request = $this->prophesize(PsrRequest::class);
+        $request = $this->prophesize('Zend\Diactoros\ServerRequest');
         $request->getUri()->willReturn('/foo');
         $request->getMethod()->willReturn('GET');
 
@@ -339,7 +339,7 @@ class FinalHandlerTest extends TestCase
             $request->reveal(),
             $response
         );
-        $this->assertInstanceOf(Response::class, $test);
+        $this->assertInstanceOf('Zend\Stratigility\Http\Response', $test);
         $this->assertSame(404, $test->getStatusCode());
 
         $body = $test->getBody();

--- a/test/FinalHandlerTest.php
+++ b/test/FinalHandlerTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Stratigility;
 
 use Exception;
 use PHPUnit_Framework_TestCase as TestCase;
+use Psr\Http\Message\StreamInterface;
 use Zend\Diactoros\ServerRequest as PsrRequest;
 use Zend\Diactoros\Response as PsrResponse;
 use Zend\Diactoros\Uri;
@@ -236,5 +237,113 @@ class FinalHandlerTest extends TestCase
         $actualResponse = self::readAttribute($final, 'response');
         $this->assertSame($originalResponse, $actualResponse);
         $this->assertSame(3, $actualResponse->getBody()->getSize());
+    }
+
+    /**
+     * @group 53
+     */
+    public function testShouldNotMarkStratigilityResponseAsCompleteWhenHandlingErrors()
+    {
+        $error = new Exception('Exception message', 501);
+
+        $response = $this->prophesize(Response::class);
+        $response->getStatusCode()->willReturn(200);
+        $response->withStatus(501, '')->will(function () use ($response) {
+            return $response->reveal();
+        });
+        $response->getReasonPhrase()->willReturn('Not Implemented');
+        $response->write('Not Implemented')->will(function () use ($response) {
+            return $response->reveal();
+        });
+
+        $final = new FinalHandler([], new Response(new PsrResponse()));
+        $this->assertSame($response->reveal(), $final(
+            $this->prophesize(Request::class)->reveal(),
+            $response->reveal(),
+            $error
+        ));
+    }
+
+    /**
+     * @group 53
+     */
+    public function testShouldNotDecoratePsrResponseAsStratigilityCompletedResponseWhenHandlingErrors()
+    {
+        $error = new Exception('Exception message', 501);
+
+        $response = (new PsrResponse())
+            ->withStatus(200);
+
+        $final = new FinalHandler([], new Response(new PsrResponse()));
+        $test = $final(
+            $this->prophesize(Request::class)->reveal(),
+            $response,
+            $error
+        );
+
+        $this->assertInstanceOf(Response::class, $test);
+        $this->assertSame(501, $test->getStatusCode());
+        $this->assertSame('Not Implemented', $test->getReasonPhrase());
+
+        $body = $test->getBody();
+        $body->rewind();
+        $this->assertContains('Not Implemented', $body->getContents());
+    }
+
+    /**
+     * @group 53
+     */
+    public function testShouldNotMarkStratigilityResponseAsCompleteWhenCreating404s()
+    {
+        $body     = $this->prophesize(StreamInterface::class);
+        $body->getSize()->willReturn(0)->shouldBeCalledTimes(2);
+
+        $response = $this->prophesize(Response::class);
+        $response->getBody()->will(function () use ($body) {
+            return $body->reveal();
+        });
+        $response->withStatus(404)->will(function () use ($response) {
+            return $response->reveal();
+        });
+        $response
+            ->write("Cannot GET /foo\n")
+            ->will(function () use ($response) {
+                return $response->reveal();
+            })
+            ->shouldBeCalled();
+
+        $request = $this->prophesize(PsrRequest::class);
+        $request->getUri()->willReturn('/foo');
+        $request->getMethod()->willReturn('GET');
+
+        $final = new FinalHandler([], $response->reveal());
+        $this->assertSame($response->reveal(), $final(
+            $request->reveal(),
+            $response->reveal()
+        ));
+    }
+
+    /**
+     * @group 53
+     */
+    public function testShouldNotDecoratePsrResponseAsStratigilityCompletedResponseWhenCreating404s()
+    {
+        $response = new PsrResponse();
+
+        $request = $this->prophesize(PsrRequest::class);
+        $request->getUri()->willReturn('/foo');
+        $request->getMethod()->willReturn('GET');
+
+        $final = new FinalHandler([], $response);
+        $test = $final(
+            $request->reveal(),
+            $response
+        );
+        $this->assertInstanceOf(Response::class, $test);
+        $this->assertSame(404, $test->getStatusCode());
+
+        $body = $test->getBody();
+        $body->rewind();
+        $this->assertContains('Cannot GET /foo', $body->getContents());
     }
 }


### PR DESCRIPTION
As reported in #53, because utilities such as the `SapiEmitter` need to update the response prior to sending it, marking the response as complete has an adverse impact since the release of 1.2.0, as this will now cause an exception.

This patch fixes that situation by using the `write()` method in favor of `end()` within the `FinalHandler::completeResponse()` method.