### PR TITLE
Host routing

### DIFF
--- a/doc/book/api.md
+++ b/doc/book/api.md
@@ -10,7 +10,11 @@ previously. Its API is:
 ```php
 class MiddlewarePipe implements MiddlewareInterface
 {
-    public function pipe(string|callable $path, callable $middleware = null);
+    public function pipe(
+        string|callable $path, 
+        string|callable $host = null, 
+        callable $middleware = null
+    );
     public function __invoke(
         Psr\Http\Message\ServerRequestInterface $request = null,
         Psr\Http\Message\ResponseInterface $response = null,
@@ -19,10 +23,14 @@ class MiddlewarePipe implements MiddlewareInterface
 }
 ```
 
-`pipe()` takes up to two arguments. If only one argument is provided, `$middleware` will be assigned
-that value, and `$path` will be re-assigned to the value `/`; this is an indication that the
-`$middleware` should be invoked for any path. If `$path` is provided, the `$middleware` will only be
-executed for that path and any subpaths.
+`pipe()` takes up to three arguments.  
+If only one argument is provided, `$middleware` will be assigned
+that value, `$path` will be re-assigned to the value `/` and `$host` to `null`; this is an indication that the
+`$middleware` should be invoked for any path on any host.  
+If two arguments are provided, `$middleware` will be assigned to the second parameter, while `$host` will be re-assigned
+ to null. `$middleware` will be executed for the path given in first argument and it's subpaths.  
+If three arguments are provided, `$middleware` will be executed on the provided path and it's subpaths only when 
+`$host` matches the host part of the request's URL.
 
 Middleware is executed in the order in which it is piped to the `MiddlewarePipe` instance.
 

--- a/doc/book/executing-middleware.md
+++ b/doc/book/executing-middleware.md
@@ -9,10 +9,17 @@ matched.
 $api = new MiddlewarePipe();  // API middleware collection
 $api->pipe(/* ... */);        // repeat as necessary
 
+$docs = new MiddlewarePipe(); // Documentation middleware collection
+$docs->pipe(/* ... */);       // Can include auth middleware, routing etc
+
 $app = new MiddlewarePipe();  // Middleware representing the application
 $app->pipe('/api', $api);     // API middleware attached to the path "/api"
+$app->pipe(                   
+    '/',                      // Documentation will be available   
+    'docs.example.com',       // only under docs.example.com   
+    $docs
+);
 ```
-
 
 Another approach is to extend the `Zend\Stratigility\MiddlewarePipe` class itself, particularly if
 you want to allow attaching other middleware to your own middleware. In such a case, you will

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -84,6 +84,9 @@ class MiddlewarePipe implements MiddlewareInterface
      * path is matched when that middleware is invoked, it will be processed;
      * otherwise it is skipped.
      *
+     * Additionally host can be specified, so the middleware will be invoked
+     * only if host is matched.
+     *
      * No path means it should be executed every request cycle.
      *
      * A handler CAN implement MiddlewareInterface, but MUST be callable.
@@ -96,14 +99,26 @@ class MiddlewarePipe implements MiddlewareInterface
      * @see ErrorMiddlewareInterface
      * @see Next
      * @param string|callable|object $path Either a URI path prefix, or middleware.
+     * @param null|string|callable|object Either URI host, or middleware.
      * @param null|callable|object $middleware Middleware
      * @return self
      */
-    public function pipe($path, $middleware = null)
+    public function pipe($path, $host = null, $middleware = null)
     {
-        if (null === $middleware && is_callable($path)) {
+
+        // One argument invoke
+        if (null === $host
+            && $middleware == null
+            && is_callable($path)
+        ) {
             $middleware = $path;
             $path       = '/';
+        }
+
+        // Two arguments invoke
+        if (null == $middleware && is_callable($host)) {
+            $middleware = $host;
+            $host = null;
         }
 
         // Ensure we have a valid handler
@@ -113,6 +128,7 @@ class MiddlewarePipe implements MiddlewareInterface
 
         $this->pipeline->enqueue(new Route(
             $this->normalizePipePath($path),
+            $host,
             $middleware
         ));
 

--- a/src/Next.php
+++ b/src/Next.php
@@ -91,7 +91,6 @@ class Next
 
         $layer           = $this->queue->dequeue();
         $path            = $request->getUri()->getPath() ?: '/';
-        $host            = $request->getUri()->getHost();
 
         $route           = $layer->path;
         $routeHost       = $layer->host;
@@ -110,7 +109,7 @@ class Next
         }
 
         // Skip if route host is defined and does not match current url
-        if ($routeHost !== null && $host != $routeHost) {
+        if ($routeHost !== null && $request->getUri()->getHost() != $routeHost) {
             return $this($request, $response, $err);
         }
 

--- a/src/Next.php
+++ b/src/Next.php
@@ -91,7 +91,11 @@ class Next
 
         $layer           = $this->queue->dequeue();
         $path            = $request->getUri()->getPath() ?: '/';
+        $host            = $request->getUri()->getHost();
+
         $route           = $layer->path;
+        $routeHost       = $layer->host;
+
         $normalizedRoute = (strlen($route) > 1) ? rtrim($route, '/') : $route;
 
         // Skip if layer path does not match current url
@@ -102,6 +106,11 @@ class Next
         // Skip if match is not at a border ('/', '.', or end)
         $border = $this->getBorder($path, $normalizedRoute);
         if ($border && '/' !== $border && '.' !== $border) {
+            return $this($request, $response, $err);
+        }
+
+        // Skip if route host is defined and does not match current url
+        if ($routeHost !== null && $host != $routeHost) {
             return $this($request, $response, $err);
         }
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -15,10 +15,11 @@ use OutOfRangeException;
 /**
  * Value object representing route-based middleware
  *
- * Details the subpath on which the middleware is active, and the
+ * Details the subpath, optionally host, on which the middleware is active, and the
  * handler for the middleware itself.
  *
  * @property-read callable $handler Handler for this route
+ * @property-read string $host Host for this route
  * @property-read string $path Path for this route
  */
 class Route
@@ -31,19 +32,31 @@ class Route
     /**
      * @var string
      */
+    protected $host;
+
+    /**
+     * @var string
+     */
     protected $path;
 
     /**
      * @param string $path
+     * @param string|callable $host
      * @param callable $handler
      */
-    public function __construct($path, callable $handler)
+    public function __construct($path, $host, callable $handler = null)
     {
         if (! is_string($path)) {
             throw new InvalidArgumentException('Path must be a string');
         }
 
+        if (is_callable($host)) {
+            $handler = $host;
+            $host = null;
+        }
+
         $this->path    = $path;
+        $this->host    = $host;
         $this->handler = $handler;
     }
 
@@ -55,7 +68,7 @@ class Route
     public function __get($name)
     {
         if (! property_exists($this, $name)) {
-            throw new OutOfRangeException('Only the path and handler may be accessed from a Route instance');
+            throw new OutOfRangeException('Only the path, host and handler may be accessed from a Route instance');
         }
         return $this->{$name};
     }

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -19,9 +19,12 @@ class RouteTest extends TestCase
         $path = '/foo';
         $handler = function () {
         };
-        $route = new Route($path, $handler);
+        $host = 'foo.example';
+
+        $route = new Route($path, $host, $handler);
         $this->assertSame($path, $route->path);
         $this->assertSame($handler, $route->handler);
+        $this->assertSame($host, $route->host);
     }
 
     public function nonStringPaths()
@@ -53,5 +56,18 @@ class RouteTest extends TestCase
 
         $this->setExpectedException('OutOfRangeException');
         $foo = $route->foo;
+    }
+
+    public function testTwoArgumentsInvocation()
+    {
+
+        $path = '/foo';
+        $handler = function () {
+        };
+
+        $route = new Route($path, $handler);
+
+        $this->assertSame($path, $route->path);
+        $this->assertSame($handler, $route->handler);
     }
 }


### PR DESCRIPTION
This PR implements a method to skip the dispatch process in Next if a defined host part of the URI is not matched, along with slight MiddlewarePipe::pipe() API change allowing host defining. 
No BC breaks are introduced, MiddlewarePipe::pipe() will accept 1, 2 or three arguments.

PR for zend-expressive including support for host routing will follow shortly, in an attempt to implement a solution for the https://github.com/zendframework/zend-expressive/issues/235 issue.