### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
     - secure: "XIgjYGyiogFeDNIbwrqoNif8ui7SEcmjhu5EchtLB6F84D9WWQ8LWwqB6PC4aeF4w4kgHmEUthqutX3VYOnNEHGL0zNVMyjlYQ2aQZUQMo53Lui/fIWZQbZIeVC/1AwZ/GOVdoLljvqHNlpDMM38DlGCmnlWzU9f58UtPefjfZ2e0emX4uERJODoQaIH4MqYC2YyGFVK8ki/IQAXa70tVGQqysciz1mhVHUhHJpb+EhJAlmxdh7bVg8hcgKHovPjYDcsJgHyG7/k71pLHun7FcpzGyx97iTJSqiEEQuRi01N3wHY9NOqK6XltV3klBwensrN/t7QiEmrupgAggog3yO9uiN18MkKuszGOGehXa5xKLYfpJzxq+jfwsv13gxiWqTU1DK8FtxcH5OH8168FkFF/UEzSBraFwYPI9KmfZ8BnoIXBvLnFf51clGH63dccd11Q51WxSF4+0v4ddovb/onRnVOZC0Qo3kJE00eg7k0h8A0AjgzwG88L1dZq6JlIHWAEPRonVxp1UI8ufGv0ZToZoG8ZBh+trKiRHnlO32N7fmRd3/inbd58+JTb3yMw8cH8l85dp2s0Vcp/xdW+2JYXrMXhF4SF0HBa8p4pqzIWR1n35RtHHuFUoac8e2rBkIBHmOW3puc+STLA+057zFo5T7U+hSoTK7LrTW8UU4="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.4
     - php: 5.5


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.