### PR TITLE
Deprecate FinalHandler and ErrorMiddlewareInterface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   directories:
     - $HOME/.composer/cache
     - $HOME/.local
+    - vendor
     - zf-mkdoc-theme
 
 env:
@@ -18,8 +19,6 @@ env:
 
 matrix:
   include:
-    - php: 5.4
-    - php: 5.5
     - php: 5.6
       env:
         - EXECUTE_CS_CHECK=true
@@ -30,9 +29,12 @@ matrix:
   allow_failures:
     - php: hhvm
 
-before_script:
-  - composer self-update
-  - composer install --prefer-source
+before_install:
+  - travis_retry composer self-update
+
+install:
+  - travis_retry composer install
+  - composer show --installed
 
 script:
   - composer test

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     }
   },
   "require": {
-    "php": "^5.4.8 || ^7.0",
+    "php": "^5.6 || ^7.0",
     "psr/http-message": "~1.0.0",
     "zendframework/zend-escaper": "~2.3"
   },

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
   },
   "require": {
     "php": "^5.6 || ^7.0",
-    "psr/http-message": "~1.0.0",
-    "zendframework/zend-escaper": "~2.3"
+    "psr/http-message": "^1.0",
+    "zendframework/zend-escaper": "^2.3"
   },
   "require-dev": {
-    "zendframework/zend-diactoros": "~1.0",
+    "zendframework/zend-diactoros": "^1.0",
     "phpunit/phpunit": "^4.7 || ^5.5",
-    "squizlabs/php_codesniffer": "^2.3.1"
+    "squizlabs/php_codesniffer": "^2.6.2"
   },
   "suggest": {
     "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Stratigility; e.g., zendframework/zend-diactoros"

--- a/doc/book/creating-middleware.md
+++ b/doc/book/creating-middleware.md
@@ -1,14 +1,15 @@
 # Creating Middleware
 
-To create middleware, write a callable capable of receiving minimally PSR-7 ServerRequest and Response
-objects, and optionally a callback to call the next in the chain.  In your middleware, you can handle
-as much or as little of the request as you want, including delegating to other middleware. If your
-middleware accepts a third argument, `$next`, it can allow further processing or return handling to
-the parent middleware by calling it.
+To create middleware, write a callable capable of receiving minimally PSR-7
+ServerRequest and Response objects, and a callback to call the next middleware
+in the chain. In your middleware, you can handle as much or as little of the
+request as you want, including delegating to other middleware. By accepting the
+third argument, `$next`, it can allow further processing via invoking that
+argument, or return handling to the parent middleware by returning a response.
 
-As an example, consider the following middleware which will use an external router to map the
-incoming request path to a handler; if unable to map the request, it returns processing to the next
-middleware.
+As an example, consider the following middleware which will use an external
+router to map the incoming request path to a handler; if unable to map the
+request, it returns processing to the next middleware.
 
 ```php
 function ($req, $res, $next) use ($router) {
@@ -41,14 +42,21 @@ In all cases, if you wish to implement typehinting, the signature is:
 function (
     Psr\Http\Message\ServerRequestInterface $request,
     Psr\Http\Message\ResponseInterface $response,
-    callable $next = null
+    callable $next
 ) : Psr\Http\Message\ResponseInterface
 ```
 
-The implementation Stratigility offers also allows you to write specialized error handler
-middleware. The signature is the same as for normal middleware, except that it expects an additional
-argument prepended to the signature, `$error`.  (Alternately, you can implement
-`Zend\Stratigility\ErrorMiddlewareInterface`.) The signature is:
+### Legacy error middleware
+
+- Deprecated since 1.3.0; to be removed in version 2.0.0. Please use the the
+  `NotFoundHandler` and `ErrorHandler` detailed in the
+  [error handling chapter](error-handlers.md), or equivalents.
+
+The implementation Stratigility offers also allows you to write specialized
+error handler middleware. The signature is the same as for normal middleware,
+except that it expects an additional argument prepended to the signature,
+`$error`.  (Alternately, you can implement `Zend\Stratigility\ErrorMiddlewareInterface`.)
+The signature is:
 
 ```php
 function (

--- a/doc/book/error-handlers.md
+++ b/doc/book/error-handlers.md
@@ -108,7 +108,7 @@ as separate layers:
 
 ```php
 // setup error handling
-$app->pipe(new ErrorHandler(new Response(), new ErrorHandler($isDevelopmentMode));
+$app->pipe(new ErrorHandler(new Response(), new ErrorResponseGenerator($isDevelopmentMode));
 
 // setup layers
 $app->pipe(/* ... */);

--- a/doc/book/error-handlers.md
+++ b/doc/book/error-handlers.md
@@ -1,7 +1,197 @@
 # Error Handlers
 
+In your application, you may need to handle error conditions:
+
+- Errors raised by PHP itself (e.g., inability to open a file or database
+  connection).
+- Exceptions/throwables raised by PHP and/or code you write or consume.
+- Inability of any middleware to handle a request.
+
+You can typically handle these conditions via middleware itself.
+
+## Handling 404 conditions
+
+If no middleware is able to handle the incoming request, this is typically
+representative of an HTTP 404 status. Stratigility provides a barebones
+middleware that you may register in an innermost layer that will return a 404
+condition, `Zend\Stratigility\Middleware\NotFoundHandler`. The class requires a
+response prototype instance that it will use to provide the 404 status and a
+message indicating the request method and URI used:
+
+```php
+// setup layers
+$app->pipe(/* ... */);
+$app->pipe(/* ... */);
+$app->pipe(new NotFoundHandler(new Response());
+
+// execute application
+```
+
+Note that it is the last middleware piped into the application! Since it returns
+a response, no deeper neseted layers will execute once it has been invoked.
+
+If you would like a templated response, you will need to write your own
+middleware; such middleware might look like the following:
+
+```php
+class NotFoundMiddleware
+{
+    private $renderer;
+
+    public function __construct(
+        TemplateRendererInterface $renderer,
+        ResponseInterface $response
+    ) {
+        $this->renderer = $renderer;
+        $this->response = $response;
+    }
+
+    public function __invoke($request)
+    {
+        $response = $this->response->withStatus(404);
+        $response->getBody()->write(
+            $this->renderer->render('error::404')
+        );
+        return $response;
+    }
+}
+```
+
+## Handling PHP errors and exceptions
+
+`Zend\Stratigility\Middleware\ErrorHandler` is a middleware implementation to
+register as the *outermost layer* of your application (or one of the outermost
+layers). It does the following:
+
+- Creates a PHP error handler that catches any errors in the `error_handling()`
+  mask and throws them as `ErrorException` instances.
+- Wraps the call to `$next()` in a try/catch block:
+  - if no exception is caught, and the result is a response, it returns it.
+  - if no exception is caught, it raises an exception, which will be caught.
+  - any caught exception is transformed into an error response.
+
+The error response will have a 5XX series status code, and the message will be
+derived from the reason phrase, if any is present. You may pass a boolean flag
+to the constructor indicating the application is in development mode; if so, the
+response will have the stack trace included in the body.
+
+In order to work, it needs a prototype response instance, and, optionally, a
+flag indicating the status of development mode (default is production mode):
+
+```php
+// setup error handling
+$app->pipe(new ErrorHandler(new Response(), $isDevelopmentMode);
+
+// setup layers
+$app->pipe(/* ... */);
+$app->pipe(/* ... */);
+```
+
+As a full example, you can combine the two middleware into the same application
+as separate layers:
+
+```php
+// setup error handling
+$app->pipe(new ErrorHandler(new Response(), $isDevelopmentMode);
+
+// setup layers
+$app->pipe(/* ... */);
+$app->pipe(/* ... */);
+
+// setup 404 handling
+$app->pipe(new NotFoundHandler(new Response());
+
+// execute application
+```
+
+The `ErrorHandler` provides no templating facilities, and only responds as text
+and/or HTML. If you want to provide a templated response, or a different
+serialization and/or markup format, you will need to write your own
+implementation. As an example:
+
+```php
+use ErrorException;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+use Zend\Stratigility\Exception\MissingResponseException;
+
+class TemplatedErrorHandler
+{
+    private $renderer;
+    private $responsePrototype;
+
+    public function __construct(TemplateRendererInterface $renderer, ResponseInterface $responsePrototype)
+    {
+        $this->renderer = $renderer;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        set_error_handler( function ($errno, $errstr, $errfile, $errline) {
+            if (! (error_reporting() & $errno)) {
+                // error_reporting does not include this error
+                return;
+            }
+
+            throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+        });
+
+        try {
+            $response = $next($request, $response);
+
+            if (! $response instanceof ResponseInterface) {
+                throw new MissingResponseException('Application did not return a response');
+            }
+        } catch (Throwable $e) {
+            $response = $this->handleThrowable($e, $request);
+        } catch (\Exception $e) {
+            $response = $this->handleThrowable($e, $request);
+        }
+
+        restore_error_handler();
+
+        return $response;
+    }
+
+    private function handleThrowable($e, ServerRequestInterface $request)
+    {
+        $response = $this->responsePrototype->withStatus(500);
+        $response->write($this->renderer->render('error::error');
+        return $response;
+    }
+}
+```
+
+### ErrorHandler Listeners
+
+`Zend\Stratigility\ErrorHandler` provides the ability to attach *listeners*;
+these are triggered when an error or exception is caught, and provided with the
+exception/throwable raised, the original request, and the final response. These
+instances are considered immutable, so listeners are for purposes of
+logging/monitoring only.
+
+Attach listeners using `ErrorHandler::attachListener()`:
+
+```php
+$errorHandler->attachListener(function ($throwable, $request, $response) use ($logger) {
+    $message = sprintf(
+        '[%s] %s %s: %s',
+        date('Y-m-d H:i:s'),
+        $request->getMethod(),
+        (string) $request->getUri(),
+        $throwable->getMessage()
+    );
+    $logger->error($message);
+});
+```
+
+## Legacy error middleware
+
 - Deprecated starting in 1.3.0, to be removed in 2.0.0. Please see the
-  [migration guide](migration/to-v2.md#error-handling) for more details.
+  [migration guide](migration/to-v2.md#error-handling) for more details, as well
+  as the preceding section.
 
 To handle errors, you can write middleware that accepts **exactly** four arguments:
 

--- a/doc/book/error-handlers.md
+++ b/doc/book/error-handlers.md
@@ -1,5 +1,8 @@
 # Error Handlers
 
+- Deprecated starting in 1.3.0, to be removed in 2.0.0. Please see the
+  [migration guide](migration/to-v2.md#error-handling) for more details.
+
 To handle errors, you can write middleware that accepts **exactly** four arguments:
 
 ```php

--- a/doc/book/install.md
+++ b/doc/book/install.md
@@ -13,8 +13,8 @@ Stratigility has the following dependencies (which are managed by Composer):
   implementation of PSR-7; one such package is
   [Diactoros](https://zendframework.github.io/zend-diactoros/).
 
-- `zendframework/zend-escaper`, used by the `FinalHandler` for escaping error messages prior to
-  passing them to the response.
+- `zendframework/zend-escaper`, used by the `ErrorHandler` middleware and the
+  for escaping error messages prior to passing them to the response.
 
 You can provide your own request and response implementations if desired as long as they implement
 the PSR-7 HTTP message interfaces.

--- a/doc/book/migration/to-v2.md
+++ b/doc/book/migration/to-v2.md
@@ -1,0 +1,155 @@
+# Migrating to version 2
+
+Version 2 of Stratigility will be making several breaking changes to the API in
+order to provide more flexibility, promote interoperability, and reduce
+complexity.
+
+To help you prepare your code for version 2, version 1.3.0 provides several
+forwards compatibility features to assist you in the process. However, some
+changes will still require changes to your code following the 2.0 release.
+
+## Error handling
+
+Prior to version 1.3, the recommended way to handle errors was via
+[error middleware](../error-handlers.md), special middleware that accepts
+an additional initial argument representing an error. On top of this, we provide
+the concept of a "final handler", pseudo-middleware that is executed by the
+`Next` implementation when the middleware stack is exhausted, but no response
+has been returned.
+
+These approaches, however, have several shortcomings:
+
+- No other middleware frameworks implement the error middleware feature, which
+  means any middleware that calls `$next()` with the error argument will not
+  work in those other systems, and error middleware written for Stratigility
+  cannot be composed in other systems.
+- The `FinalHandler` implementation hits edge cases when empty responses are
+  intended.
+- Neither combination works well with error or exception handlers.
+
+Starting in 1.3, we are promoting using standard middleware layers as error
+handlers, instead of using the existing error middleware/final handler system.
+
+To achieve this, we have provided some new functionality, as well as augmented
+existing functionality.
+
+### Error handling middleware
+
+We broke the existing `FinalHandler` into two separate pieces, one for handling
+404 cases (i.e., no middleware was able to handle the request), and one for
+handling errors.
+
+`Zend\Stratigility\Middleware\NotFoundHandler` is a middleware implementation to
+register as the *innermost layer* of your application; when invoked, it
+immediately returns a 404 response.
+
+In order to work, it needs a prototype response instance.
+
+```php
+// setup layers
+$app->pipe(/* ... */);
+$app->pipe(/* ... */);
+$app->pipe(new NotFoundHandler(new Response());
+
+// execute application
+```
+
+`Zend\Stratigility\Middleware\ErrorHandler` is a middleware implementation to
+register as the *outermost layer* of your application (or one of the outermost
+layers). It does the following:
+
+- Creates a PHP error handler that catches any errors in the `error_handling()`
+  mask and throws them as `ErrorException` instances.
+- Wraps the call to `$next()` in a try/catch block:
+  - if no exception is caught, and the result is a response, it returns it.
+  - if no exception is caught, it raises an exception, which will be caught.
+  - any caught exception is transformed into an error response.
+
+The error response will have a 5XX series status code, and the message will be
+derived from the reason phrase, if any is present. You may pass a boolean flag
+to the constructor indicating the application is in development mode; if so, the
+response will have the stack trace included in the body.
+
+In order to work, it needs a prototype response instance, and, optionally, a
+flag indicating the status of development mode (default is production mode):
+
+```php
+// setup error handling
+$app->pipe(new ErrorHandler(new Response(), $isDevelopmentMode);
+
+// setup layers
+$app->pipe(/* ... */);
+$app->pipe(/* ... */);
+```
+
+As a full example, you can combine the two middleware into the same application
+as separate layers:
+
+```php
+// setup error handling
+$app->pipe(new ErrorHandler(new Response(), $isDevelopmentMode);
+
+// setup layers
+$app->pipe(/* ... */);
+$app->pipe(/* ... */);
+
+// setup 404 handling
+$app->pipe(new NotFoundHandler(new Response());
+
+// execute application
+```
+
+### No-op final handler
+
+When using the above strategy, the `FinalHandler` implementation loses most of
+its meaning, as you are now handling errors and 404 conditions as middleware
+layers.
+
+However, you still need to ensure that the pipeline returns a response,
+regardless of how the pipeline is setup, and for that we still need some form of
+"final" handler that can do so. (In fact, starting in version 2, the `$out`
+argument will be renamed to either `$next` or `$delegate`, and will be a
+required argument of the `MiddlewareInterface` and, thus, the `MiddlewarePipe`.)
+
+Starting in version 1.3, we now offer a `Zend\Stratigility\NoopFinalHandler`
+implementation, which simply returns the response passed to it. You can compose
+it in your application in one of two ways:
+
+- By passing it explicitly when invoking the middleware pipeline.
+- By passing it to `Zend\Diactoros\Server::listen()`.
+
+If you are not using `Zend\Diactoros\Server` to execute your application, but
+instead invoking your pipeline manually, use the following:
+
+```php
+$response = $app($request, $response, new NoopFinalHandler());
+```
+
+If you are using `Zend\Diactoros\Server`, you will need to pass the final
+handler you wish to use as an argument to the `listen()` method; that method
+will then pass that value as the third argument to `MiddlewarePipe` as shown
+above:
+
+```php
+$server->listen(new NoopFinalHandler());
+```
+
+Both approaches above are fully forwards compatible with version 2, and will
+work in all version 1 releases as well.
+
+(You can also compose your own custom final handler; it only needs to accept a
+request and a response, and be guaranteed to return a response instance.)
+
+## Deprecated functionality
+
+The following classes, methods, and arguments are deprecated starting in version
+1.3.0, and will be removed in version 2.0.0.
+
+- `Zend\Stratigility\FinalHandler` (class)
+- `Zend\Stratigility\Dispatch` (class); this class is marked internal already,
+  but anybody extending `Next` and/or this class should be aware of its removal.
+- `Zend\Stratigility\ErrorMiddlewareInterface` (interface); error middleware
+  should now be implemented per the [error handling section above](#error-handling).
+- The `$err` argument to `Zend\Stratigility\Next`'s `__invoke()` method.
+  Starting in 1.3.0, if a non-null value is encountered, this method will now
+  emit an `E_USER_DEPRECATED` notice, referencing this documentation.

--- a/doc/book/usage.md
+++ b/doc/book/usage.md
@@ -8,6 +8,7 @@ Creating an application consists of 3 steps:
 
 ```php
 use Zend\Stratigility\MiddlewarePipe;
+use Zend\Stratigility\NoopFinalHandler;
 use Zend\Diactoros\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -20,7 +21,7 @@ $server = Server::createServer($app,
   $_COOKIE,
   $_FILES
 );
-$server->listen();
+$server->listen(new NoopFinalHandler());
 ```
 
 The above example is useless by itself until you pipe middleware into the application.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,8 @@ pages:
         - "Creating Middleware": creating-middleware.md
         - "Executing and composing middleware": executing-middleware.md
         - "API Reference": api.md
+        - Migration:
+          - "To Version 2": migration/to-v2.md
 site_name: zend-stratigility
 site_description: zend-stratigility
 repo_url: 'https://github.com/zendframework/zend-stratigility'

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,6 +9,12 @@
     <!-- inherit rules from: -->
     <rule ref="PSR2"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.Formatting.SpaceAfterNot"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
             <property name="ignoreBlankLines" value="false"/>

--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -20,6 +20,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * This class is an implementation detail of Next.
  *
  * @internal
+ * @deprecated since 1.3.0; to be removed in 2.0.0.
  */
 class Dispatch
 {

--- a/src/ErrorMiddlewareInterface.php
+++ b/src/ErrorMiddlewareInterface.php
@@ -24,6 +24,11 @@ use Psr\Http\Message\ResponseInterface as Response;
  *
  * Error middleware does something with the arguments passed, and then
  * either returns a response, or calls `$out`, with or without the error.
+ *
+ * @deprecated since 1.3.0; will be removed with 2.0.0. Please see
+ *     https://docs.zendframework.com/zend-stratigility/migration/to-v2/
+ *     for more information on how to update your code for forwards
+ *     compatibility.
  */
 interface ErrorMiddlewareInterface
 {

--- a/src/Exception/MissingDelegateException.php
+++ b/src/Exception/MissingDelegateException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stratigility\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * Exception to raise when $next argument is missing.
+ */
+class MissingDelegateException extends InvalidArgumentException
+{
+}

--- a/src/Exception/MissingResponseException.php
+++ b/src/Exception/MissingResponseException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stratigility\Exception;
+
+use OutOfBoundsException;
+
+/**
+ * Exception thrown when the internal stack of Zend\Stratigility\Next is
+ * exhausted, but no response returned.
+ */
+class MissingResponseException extends OutOfBoundsException
+{
+}

--- a/src/FinalHandler.php
+++ b/src/FinalHandler.php
@@ -16,6 +16,11 @@ use Zend\Escaper\Escaper;
 
 /**
  * Handle incomplete requests
+ *
+ * @deprecated since 1.3.0; will be removed with 2.0.0. Please see
+ *     https://docs.zendframework.com/zend-stratigility/migration/to-v2/
+ *     for more information on how to update your code for forwards
+ *     compatibility.
  */
 class FinalHandler
 {

--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use ErrorException;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+use Zend\Escaper\Escaper;
+use Zend\Stratigility\Exception\MissingResponseException;
+use Zend\Stratigility\Utils;
+
+class ErrorHandler
+{
+    /**
+     * @var bool
+     */
+    private $isDevelopmentMode;
+
+    /**
+     * @var callable[]
+     */
+    private $listeners = [];
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    /**
+     * @param ResponseInterface $responsePrototype Empty/prototype response to
+     *     update and return when returning an error response.
+     * @param bool $isDevelopmentMode
+     */
+    public function __construct(ResponseInterface $responsePrototype, $isDevelopmentMode = false)
+    {
+        $this->responsePrototype = $responsePrototype;
+        $this->isDevelopmentMode = (bool) $isDevelopmentMode;
+    }
+
+    /**
+     * Attach an error listener.
+     *
+     * Each listener receives the following three arguments:
+     *
+     * - \Throwable|\Exception $error
+     * - ServerRequestInterface $request
+     * - ResponseInterface $response
+     *
+     * These instances are all immutable, and the return values of
+     * listeners are ignored; use listeners for reporting purposes
+     * only.
+     *
+     * @param callable $listener
+     */
+    public function attachListener(callable $listener)
+    {
+        if (in_array($listener, $this->listeners, true)) {
+            return;
+        }
+
+        $this->listeners[] = $listener;
+    }
+
+    /**
+     * Middleware to handle errors and exceptions in layers it wraps.
+     *
+     * Adds an error handler that will convert PHP errors to ErrorException
+     * instances.
+     *
+     * Internally, wraps the call to $next() in a try/catch block, catching
+     * all PHP Throwables (PHP 7) and Exceptions (PHP 5.6 and earlier).
+     *
+     * When an exception is caught, an appropriate error response is created
+     * and returned instead; otherwise, the response returned by $next is
+     * used.
+     *
+     * @param ServerRequestInterface $request
+     * @return ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        set_error_handler($this->createErrorHandler());
+
+        try {
+            $response = $next($request, $response);
+
+            if (! $response instanceof ResponseInterface) {
+                throw new MissingResponseException('Application did not return a response');
+            }
+        } catch (Throwable $e) {
+            $response = $this->handleThrowable($e, $request);
+        } catch (\Exception $e) {
+            $response = $this->handleThrowable($e, $request);
+        }
+
+        restore_error_handler();
+
+        return $response;
+    }
+
+    /**
+     * @param Throwable|\Exception $e
+     * @param ServerRequestInterface $request
+     * @return ResponseInterface
+     */
+    private function handleThrowable($e, ServerRequestInterface $request)
+    {
+        $response = $this->responsePrototype->withStatus(Utils::getStatusCode($e, $this->responsePrototype));
+        $message = $response->getReasonPhrase() ?: 'Unknown Error';
+
+        if ($this->isDevelopmentMode) {
+            $message = $this->createDevelopmentErrorMessage($e);
+        }
+
+        $response->getBody()->write($message);
+
+        $this->triggerListeners($e, $request, $response);
+
+        return $response;
+    }
+
+    /**
+     * Creates and returns a callable error handler that raises exceptions.
+     *
+     * Only raises exceptions for errors that are within the error_reporting mask.
+     *
+     * @return callable
+     */
+    private function createErrorHandler()
+    {
+        /**
+         * @param int $errno
+         * @param string $errstr
+         * @param string $errfile
+         * @param int $errline
+         * @return void
+         * @throws ErrorException if error is not within the error_reporting mask.
+         */
+        return function ($errno, $errstr, $errfile, $errline) {
+            if (! (error_reporting() & $errno)) {
+                // error_reporting does not include this error
+                return;
+            }
+
+            throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+        };
+    }
+
+    /**
+     * Trigger all error listeners.
+     *
+     * @param Throwable|\Exception $error
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @return void
+     */
+    private function triggerListeners($error, ServerRequestInterface $request, ResponseInterface $response)
+    {
+        array_walk($this->listeners, function ($listener) use ($error, $request, $response) {
+            $listener($error, $request, $response);
+        });
+    }
+
+    /**
+     * Create a complete error message for development purposes.
+     *
+     * Creates an error message with the full exception backtrace, escaped
+     * for use in HTML.
+     *
+     * @param Throwable|\Exception $exception
+     * @return string
+     */
+    private function createDevelopmentErrorMessage($exception)
+    {
+        $escaper = new Escaper();
+        return $escaper->escapeHtml((string) $exception);
+    }
+}

--- a/src/Middleware/ErrorResponseGenerator.php
+++ b/src/Middleware/ErrorResponseGenerator.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Exception;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+use Zend\Escaper\Escaper;
+use Zend\Stratigility\Utils;
+
+final class ErrorResponseGenerator
+{
+    /**
+     * @var bool
+     */
+    private $isDevelopmentMode;
+
+    /**
+     * @param bool $isDevelopmentMode
+     */
+    public function __construct($isDevelopmentMode = false)
+    {
+        $this->isDevelopmentMode = (bool) $isDevelopmentMode;
+    }
+
+    /**
+     * Create/update the response representing the error.
+     *
+     * @param Throwable|Exception $e
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @return ResponseInterface
+     */
+    public function __invoke($e, ServerRequestInterface $request, ResponseInterface $response)
+    {
+        $response = $response->withStatus(Utils::getStatusCode($e, $response));
+        $body = $response->getBody();
+
+        if ($this->isDevelopmentMode) {
+            $escaper = new Escaper();
+            $body->write($escaper->escapeHtml((string) $e));
+            return $response;
+        }
+
+        $body->write($response->getReasonPhrase() ?: 'Unknown Error');
+        return $response;
+    }
+}

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -9,8 +9,9 @@ namespace Zend\Stratigility\Middleware;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Zend\Stratigility\MiddlewareInterface;
 
-class NotFoundHandler
+class NotFoundHandler implements MiddlewareInterface
 {
     /**
      * @var ResponseInterface
@@ -30,9 +31,11 @@ class NotFoundHandler
      * Creates and returns a 404 response.
      *
      * @param ServerRequestInterface $request
+     * @param ResponseInterface $response Ignored.
+     * @param null|callable $next Ignored.
      * @return ResponseInterface
      */
-    public function __invoke(ServerRequestInterface $request)
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next = null)
     {
         $response = $this->responsePrototype
             ->withStatus(404);

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class NotFoundHandler
+{
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    /**
+     * @param ResponseInterface $responsePrototype Empty/prototype response to
+     *     update and return when returning an 404 response.
+     */
+    public function __construct(ResponseInterface $responsePrototype)
+    {
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    /**
+     * Creates and returns a 404 response.
+     *
+     * @param ServerRequestInterface $request
+     * @return ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request)
+    {
+        $response = $this->responsePrototype
+            ->withStatus(404);
+        $response->getBody()->write(sprintf(
+            "Cannot %s %s",
+            $request->getMethod(),
+            (string) $request->getUri()
+        ));
+        return $response;
+    }
+}

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -60,6 +60,8 @@ class MiddlewarePipe implements MiddlewareInterface
      * $next has exhausted the pipeline; otherwise, a FinalHandler instance
      * is created and passed to $next during initialization.
      *
+     * @todo Make $out required for 2.0.0.
+     * @todo Remove trigger of deprecation notice when preparing for 2.0.0.
      * @param Request $request
      * @param Response $response
      * @param callable $out
@@ -69,6 +71,16 @@ class MiddlewarePipe implements MiddlewareInterface
     {
         $request  = $this->decorateRequest($request);
         $response = $this->decorateResponse($response);
+
+        if (null === $out) {
+            trigger_error(sprintf(
+                'The third argument to %s() ($out) will be required starting with '
+                . 'Stratigility version 2; please see '
+                . 'https://docs.zendframework.com/zend-stratigility/migration/to-v2/ for '
+                . 'more details on how to update your application to remove this message.',
+                __CLASS__
+            ), E_USER_DEPRECATED);
+        }
 
         $done   = $out ?: new FinalHandler([], $response);
         $next   = new Next($this->pipeline, $done);

--- a/src/Next.php
+++ b/src/Next.php
@@ -72,7 +72,8 @@ class Next
      *
      * @param ServerRequestInterface $request
      * @param ResponseInterface $response
-     * @param null|mixed $err
+     * @param null|mixed $err This argument is deprecated as of 1.3.0, and will
+     *     be removed in 2.0.0.
      * @return ResponseInterface
      */
     public function __invoke(
@@ -80,6 +81,15 @@ class Next
         ResponseInterface $response,
         $err = null
     ) {
+        if (null !== $err) {
+            trigger_error(
+                'Usage of error middleware is deprecated as of 1.3.0, and will be removed in 2.0.0; '
+                . 'please see https://docs.zendframework.com/zend-stratigility/migration/to-v2/ '
+                . 'for details on how to update your application to remove this message.',
+                E_USER_DEPRECATED
+            );
+        }
+
         $dispatch = $this->dispatch;
         $done     = $this->done;
         $request  = $this->resetPath($request);

--- a/src/NoopFinalHandler.php
+++ b/src/NoopFinalHandler.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stratigility;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class NoopFinalHandler
+{
+    /**
+     * Final handler for all requests.
+     *
+     * This handler should only ever be invoked if Next exhausts its stack.
+     *
+     * When that happens, it returns the response provided during invocation.
+     *
+     * @param ServerRequestInterface $request Request instance.
+     * @param ResponseInterface $response Response instance.
+     * @return ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        return $response;
+    }
+}

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -13,6 +13,7 @@ use Exception;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionFunction;
 use ReflectionMethod;
+use Throwable;
 
 /**
  * Utility methods
@@ -76,7 +77,7 @@ abstract class Utils
      */
     public static function getStatusCode($error, ResponseInterface $response)
     {
-        if ($error instanceof Exception
+        if (($error instanceof Throwable || $error instanceof Exception)
             && ($error->getCode() >= 400 && $error->getCode() < 600)
         ) {
             return $error->getCode();

--- a/test/Middleware/ErrorHandlerTest.php
+++ b/test/Middleware/ErrorHandlerTest.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 use Zend\Escaper\Escaper;
+use Zend\Stratigility\Exception\MissingDelegateException;
 use Zend\Stratigility\Middleware\ErrorHandler;
 use Zend\Stratigility\Middleware\ErrorResponseGenerator;
 
@@ -223,5 +224,18 @@ class ErrorHandlerTest extends TestCase
         $result = $middleware($this->request->reveal(), $this->response->reveal(), $next);
 
         $this->assertSame($this->response->reveal(), $result);
+    }
+
+    public function testInvokingErrorHandlerWithoutNextArgumentResultsInErrorResponse()
+    {
+        $generator = function ($e, $request, $response) {
+            $this->assertInstanceOf(MissingDelegateException::class, $e);
+            return $response;
+        };
+
+        $middleware = new ErrorHandler($this->response->reveal(), $generator);
+        $response = $middleware($this->request->reveal(), $this->response->reveal());
+
+        $this->assertSame($this->response->reveal(), $response);
     }
 }

--- a/test/Middleware/ErrorHandlerTest.php
+++ b/test/Middleware/ErrorHandlerTest.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stratigility\Middleware;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+use Zend\Escaper\Escaper;
+use Zend\Stratigility\Middleware\ErrorHandler;
+
+class ErrorHandlerTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->response = $this->prophesize(ResponseInterface::class);
+        $this->request = $this->prophesize(ServerRequestInterface::class);
+        $this->body = $this->prophesize(StreamInterface::class);
+        $this->errorReporting = error_reporting();
+    }
+
+    public function tearDown()
+    {
+        error_reporting($this->errorReporting);
+    }
+
+    public function createMiddleware($isDevelopmentMode = false)
+    {
+        return new ErrorHandler($this->response->reveal(), $isDevelopmentMode);
+    }
+
+    public function testReturnsResponseFromInnerMiddlewareWhenNoProblemsOccur()
+    {
+        $expectedResponse = $this->prophesize(ResponseInterface::class)->reveal();
+        $innerMiddleware = function ($req) use ($expectedResponse) {
+            return $expectedResponse;
+        };
+
+        $next = new TestAsset\Next;
+        $next->push($innerMiddleware);
+
+        $this->response->withStatus(Argument::any())->shouldNotBeCalled();
+
+        $middleware = $this->createMiddleware();
+        $result = $middleware($this->request->reveal(), $this->response->reveal(), $next);
+
+        $this->assertSame($expectedResponse, $result);
+    }
+
+    public function testReturnsErrorResponseIfInnerMiddlewareDoesNotReturnAResponse()
+    {
+        $innerMiddleware = function () {
+        };
+
+        $next = new TestAsset\Next;
+        $next->push($innerMiddleware);
+
+        $this->body->write('Unknown Error')->shouldBeCalled();
+        $this->response->getStatusCode()->willReturn(200);
+        $this->response->withStatus(500)->will([$this->response, 'reveal']);
+        $this->response->getReasonPhrase()->willReturn('');
+        $this->response->getBody()->will([$this->body, 'reveal']);
+
+        $middleware = $this->createMiddleware();
+        $result = $middleware($this->request->reveal(), $this->response->reveal(), $next);
+
+        $this->assertSame($this->response->reveal(), $result);
+    }
+
+    public function testReturnsErrorResponseIfInnerMiddlewareRaisesAnErrorInTheErrorMask()
+    {
+        error_reporting(E_USER_DEPRECATED);
+        $innerMiddleware = function () {
+            trigger_error('Deprecated', E_USER_DEPRECATED);
+        };
+
+        $next = new TestAsset\Next;
+        $next->push($innerMiddleware);
+
+        $this->body->write('Unknown Error')->shouldBeCalled();
+        $this->response->getStatusCode()->willReturn(200);
+        $this->response->withStatus(500)->will([$this->response, 'reveal']);
+        $this->response->getReasonPhrase()->willReturn('');
+        $this->response->getBody()->will([$this->body, 'reveal']);
+
+        $middleware = $this->createMiddleware();
+        $result = $middleware($this->request->reveal(), $this->response->reveal(), $next);
+
+        $this->assertSame($this->response->reveal(), $result);
+    }
+
+    public function testReturnsResponseFromInnerMiddlewareWhenErrorRaisedIsNotInTheErrorMask()
+    {
+        $originalMask = error_reporting();
+        error_reporting($originalMask & ~E_USER_DEPRECATED);
+
+        $expectedResponse = $this->prophesize(ResponseInterface::class)->reveal();
+        $innerMiddleware = function () use ($expectedResponse) {
+            trigger_error('Deprecated', E_USER_DEPRECATED);
+            return $expectedResponse;
+        };
+
+        $next = new TestAsset\Next;
+        $next->push($innerMiddleware);
+
+        $this->body->write('Unknown Error')->shouldNotBeCalled();
+        $this->response->getStatusCode()->shouldNotBeCalled();
+        $this->response->withStatus(Argument::any())->shouldNotBeCalled();
+
+        $middleware = $this->createMiddleware();
+        $result = $middleware($this->request->reveal(), $this->response->reveal(), $next);
+
+        $this->assertSame($expectedResponse, $result);
+    }
+
+    public function testReturnsErrorResponseIfInnerMiddlewareRaisesAnException()
+    {
+        $innerMiddleware = function () {
+            throw new RuntimeException('Exception raised', 503);
+        };
+
+        $next = new TestAsset\Next;
+        $next->push($innerMiddleware);
+
+        $this->body->write('Unknown Error')->shouldBeCalled();
+        $this->response->getStatusCode()->willReturn(200);
+        $this->response->withStatus(503)->will([$this->response, 'reveal']);
+        $this->response->getReasonPhrase()->willReturn('');
+        $this->response->getBody()->will([$this->body, 'reveal']);
+
+        $middleware = $this->createMiddleware();
+        $result = $middleware($this->request->reveal(), $this->response->reveal(), $next);
+
+        $this->assertSame($this->response->reveal(), $result);
+    }
+
+    public function testResponseErrorMessageIncludesStackTraceIfDevelopmentModeIsEnabled()
+    {
+        $exception = new RuntimeException('Exception raised', 503);
+        $innerMiddleware = function () use ($exception) {
+            throw $exception;
+        };
+
+        $next = new TestAsset\Next;
+        $next->push($innerMiddleware);
+
+        $this->body
+            ->write((new Escaper())
+            ->escapeHtml((string) $exception))->shouldBeCalled();
+        $this->response->getStatusCode()->willReturn(200);
+        $this->response->withStatus(503)->will([$this->response, 'reveal']);
+        $this->response->getReasonPhrase()->willReturn('');
+        $this->response->getBody()->will([$this->body, 'reveal']);
+
+        $middleware = $this->createMiddleware(true);
+        $result = $middleware($this->request->reveal(), $this->response->reveal(), $next);
+
+        $this->assertSame($this->response->reveal(), $result);
+    }
+
+    public function testErrorHandlingTriggersListeners()
+    {
+        $exception = new RuntimeException('Exception raised', 503);
+
+        $innerMiddleware = function () use ($exception) {
+            throw $exception;
+        };
+
+        $next = new TestAsset\Next;
+        $next->push($innerMiddleware);
+
+        $this->body->write('Unknown Error')->shouldBeCalled();
+        $this->response->getStatusCode()->willReturn(200);
+        $this->response->withStatus(503)->will([$this->response, 'reveal']);
+        $this->response->getReasonPhrase()->willReturn('');
+        $this->response->getBody()->will([$this->body, 'reveal']);
+
+        $listener = function ($error, $request, $response) use ($exception) {
+            $this->assertSame($exception, $error, 'Listener did not receive same exception as was raised');
+            $this->assertSame($this->request->reveal(), $request, 'Listener did not receive same request');
+            $this->assertSame($this->response->reveal(), $response, 'Listener did not receive same response');
+        };
+        $listener2 = clone $listener;
+
+        $middleware = $this->createMiddleware();
+        $middleware->attachListener($listener);
+        $middleware->attachListener($listener2);
+
+        $result = $middleware($this->request->reveal(), $this->response->reveal(), $next);
+
+        $this->assertSame($this->response->reveal(), $result);
+    }
+}

--- a/test/Middleware/NotFoundHandlerTest.php
+++ b/test/Middleware/NotFoundHandlerTest.php
@@ -30,6 +30,9 @@ class NotFoundHandlerTest extends TestCase
 
         $middleware = new NotFoundHandler($response->reveal());
 
-        $this->assertSame($response->reveal(), $middleware($request->reveal()));
+        $this->assertSame(
+            $response->reveal(),
+            $middleware($request->reveal(), $this->prophesize(ResponseInterface::class)->reveal())
+        );
     }
 }

--- a/test/Middleware/NotFoundHandlerTest.php
+++ b/test/Middleware/NotFoundHandlerTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stratigility\Middleware;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Zend\Stratigility\Middleware\NotFoundHandler;
+
+class NotFoundHandlerTest extends TestCase
+{
+    public function testReturnsResponseWith404StatusAndErrorMessageInBody()
+    {
+        $stream = $this->prophesize(StreamInterface::class);
+        $stream->write('Cannot POST https://example.com/foo');
+
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->withStatus(404)->will([$response, 'reveal']);
+        $response->getBody()->will([$stream, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn('POST');
+        $request->getUri()->willReturn('https://example.com/foo');
+
+        $middleware = new NotFoundHandler($response->reveal());
+
+        $this->assertSame($response->reveal(), $middleware($request->reveal()));
+    }
+}

--- a/test/Middleware/TestAsset/Next.php
+++ b/test/Middleware/TestAsset/Next.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stratigility\Middleware\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class Next
+{
+    /**
+     * @var callable[]
+     */
+    private $middleware = [];
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @return ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        if (0 === count($this->middleware)) {
+            return $response;
+        }
+
+        $middleware = array_shift($this->middleware);
+        return $middleware($request, $response);
+    }
+
+    /**
+     * @param callable $middleware
+     * @return void
+     */
+    public function push(callable $middleware)
+    {
+        $this->middleware[] = $middleware;
+    }
+}

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -76,6 +76,9 @@ class MiddlewarePipeTest extends TestCase
         $this->assertContains('Third', $body);
     }
 
+    /**
+     * @todo remove for 2.0.0
+     */
     public function testHandleInvokesFirstErrorHandlerOnErrorInChain()
     {
         $this->middleware->pipe(function ($req, $res, $next) {
@@ -95,8 +98,16 @@ class MiddlewarePipeTest extends TestCase
             $phpunit->fail('Should not hit fourth handler!');
         });
 
+        set_error_handler(function ($errno, $errstr) {
+            // no-op; skip handling
+            return true;
+        }, E_USER_DEPRECATED);
+
         $request  = new Request([], [], 'http://local.example.com/foo', 'GET', 'php://memory');
         $response = $this->middleware->__invoke($request, $this->response);
+
+        restore_error_handler();
+
         $body     = (string) $response->getBody();
         $this->assertContains('First', $body);
         $this->assertContains('ERROR HANDLER', $body);

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -17,15 +17,44 @@ use Zend\Diactoros\Uri;
 use Zend\Stratigility\Http\Request as RequestDecorator;
 use Zend\Stratigility\Http\Response as ResponseDecorator;
 use Zend\Stratigility\MiddlewarePipe;
+use Zend\Stratigility\NoopFinalHandler;
 use Zend\Stratigility\Utils;
 
 class MiddlewarePipeTest extends TestCase
 {
+    public $deprecationsSuppressed = false;
+
     public function setUp()
     {
+        $this->deprecationsSuppressed = false;
         $this->request    = new Request([], [], 'http://example.com/', 'GET', 'php://memory');
         $this->response   = new Response();
         $this->middleware = new MiddlewarePipe();
+    }
+
+    public function tearDown()
+    {
+        if (false !== $this->deprecationsSuppressed) {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * @return NoopFinalHandler
+     */
+    public function createFinalHandler()
+    {
+        return new NoopFinalHandler();
+    }
+
+    public function suppressDeprecationNotice()
+    {
+        $this->deprecationsSuppressed = set_error_handler(function ($errno, $errstr) {
+            if (false === strstr($errstr, 'docs.zendframework.com')) {
+                return false;
+            }
+            return true;
+        }, E_USER_DEPRECATED);
     }
 
     public function invalidHandlers()
@@ -63,13 +92,13 @@ class MiddlewarePipeTest extends TestCase
         $this->middleware->pipe(function ($req, $res, $next) {
             $res->write("Third\n");
         });
-        $phpunit = $this;
-        $this->middleware->pipe(function ($req, $res, $next) use ($phpunit) {
-            $phpunit->fail('Should not hit fourth handler!');
+
+        $this->middleware->pipe(function ($req, $res, $next) {
+            $this->fail('Should not hit fourth handler!');
         });
 
         $request = new Request([], [], 'http://local.example.com/foo', 'GET', 'php://memory');
-        $this->middleware->__invoke($request, $this->response);
+        $this->middleware->__invoke($request, $this->response, $this->createFinalHandler());
         $body = (string) $this->response->getBody();
         $this->assertContains('First', $body);
         $this->assertContains('Second', $body);
@@ -136,46 +165,35 @@ class MiddlewarePipeTest extends TestCase
         $this->assertTrue($triggered);
     }
 
-    public function testPipeWillCreateErrorClosureForObjectImplementingHandle()
-    {
-        $this->markTestIncomplete();
-        $handler = new TestAsset\ErrorHandler();
-        $this->middleware->pipe($handler);
-        $r = new ReflectionProperty($this->middleware, 'queue');
-        $r->setAccessible(true);
-        $queue = $r->getValue($this->middleware);
-        $route = $queue[$queue->count() - 1];
-        $this->assertInstanceOf('Zend\Stratigility\Route', $route);
-        $handler = $route->handler;
-        $this->assertInstanceOf('Closure', $handler);
-        $this->assertEquals(4, Utils::getArity($handler));
-    }
-
     public function testCanUseDecoratedRequestAndResponseDirectly()
     {
         $baseRequest = new Request([], [], 'http://local.example.com/foo', 'GET', 'php://memory');
 
         $request  = new RequestDecorator($baseRequest);
         $response = new ResponseDecorator($this->response);
-        $phpunit  = $this;
         $executed = false;
 
         $middleware = $this->middleware;
-        $middleware->pipe(function ($req, $res, $next) use ($phpunit, $request, $response, &$executed) {
-            $phpunit->assertSame($request, $req);
-            $phpunit->assertSame($response, $res);
+        $middleware->pipe(function ($req, $res, $next) use ($request, $response, &$executed) {
+            $this->assertSame($request, $req);
+            $this->assertSame($response, $res);
             $executed = true;
         });
 
-        $middleware($request, $response, function ($err = null) use ($phpunit) {
-            $phpunit->fail('Next should not be called');
+        $middleware($request, $response, function ($err = null) {
+            $this->fail('Next should not be called');
         });
 
         $this->assertTrue($executed);
     }
 
-    public function testReturnsOrigionalResponseIfQueueDoesNotReturnAResponse()
+    /**
+     * @todo Update invocation to provide a no-op final handler for 2.0
+     */
+    public function testReturnsOrigionalResponseIfQueueDoesNotReturnAResponseAndNoFinalHandlerRegistered()
     {
+        $this->suppressDeprecationNotice();
+
         $this->middleware->pipe(function ($req, $res, $next) {
             $next($req, $res);
         });
@@ -208,13 +226,13 @@ class MiddlewarePipeTest extends TestCase
         $this->middleware->pipe(function ($req, $res, $next) use ($return) {
             return $return;
         });
-        $phpunit = $this;
-        $this->middleware->pipe(function ($req, $res, $next) use ($phpunit) {
-            $phpunit->fail('Should not hit fourth handler!');
+
+        $this->middleware->pipe(function ($req, $res, $next) {
+            $this->fail('Should not hit fourth handler!');
         });
 
         $request = new Request([], [], 'http://local.example.com/foo', 'GET', 'php://memory');
-        $result  = $this->middleware->__invoke($request, $this->response);
+        $result  = $this->middleware->__invoke($request, $this->response, $this->createFinalHandler());
         $this->assertSame($return, $result, var_export([
             spl_object_hash($return) => get_class($return),
             spl_object_hash($result) => get_class($result),
@@ -226,12 +244,13 @@ class MiddlewarePipeTest extends TestCase
         $this->middleware->pipe('/admin', function ($req, $res, $next) {
             return $next($req, $res);
         });
-        $phpunit = $this;
-        $this->middleware->pipe(function ($req, $res, $next) use ($phpunit) {
+
+        $this->middleware->pipe(function ($req, $res, $next) {
             return $res->write($req->getUri()->getPath());
         });
+
         $request = new Request([], [], 'http://local.example.com/admin', 'GET', 'php://memory');
-        $result  = $this->middleware->__invoke($request, $this->response);
+        $result  = $this->middleware->__invoke($request, $this->response, $this->createFinalHandler());
         $body    = (string) $result->getBody();
         $this->assertSame('/admin', $body);
     }
@@ -241,12 +260,13 @@ class MiddlewarePipeTest extends TestCase
         $this->middleware->pipe('/admin', function ($req, $res, $next) {
             return $next($req, $res);
         });
-        $phpunit = $this;
-        $this->middleware->pipe(function ($req, $res, $next) use ($phpunit) {
+
+        $this->middleware->pipe(function ($req, $res, $next) {
             return $res->write($req->getUri()->getPath());
         });
+
         $request = new Request([], [], 'http://local.example.com/admin/', 'GET', 'php://memory');
-        $result  = $this->middleware->__invoke($request, $this->response);
+        $result  = $this->middleware->__invoke($request, $this->response, $this->createFinalHandler());
         $body    = (string) $result->getBody();
         $this->assertSame('/admin/', $body);
     }
@@ -271,7 +291,7 @@ class MiddlewarePipeTest extends TestCase
         });
 
         $request = new Request([], [], 'http://local.example.com/test', 'GET', 'php://memory');
-        $result  = $this->middleware->__invoke($request, $this->response);
+        $result  = $this->middleware->__invoke($request, $this->response, $this->createFinalHandler());
         $this->assertTrue($triggered);
         $this->assertInstanceOf('Zend\Stratigility\Http\Response', $result);
         $this->assertSame($this->response, $result->getOriginalResponse());
@@ -280,16 +300,14 @@ class MiddlewarePipeTest extends TestCase
     public function testMiddlewareRequestPathMustBeTrimmedOffWithPipeRoutePath()
     {
         $request  = new Request([], [], 'http://local.example.com/foo/bar', 'GET', 'php://memory');
-
-        $phpunit  = $this;
         $executed = false;
 
-        $this->middleware->pipe('/foo', function ($req, $res, $next) use ($phpunit, &$executed) {
-            $phpunit->assertEquals('/bar', $req->getUri()->getPath());
+        $this->middleware->pipe('/foo', function ($req, $res, $next) use (&$executed) {
+            $this->assertEquals('/bar', $req->getUri()->getPath());
             $executed = true;
         });
 
-        $this->middleware->__invoke($request, $this->response);
+        $this->middleware->__invoke($request, $this->response, $this->createFinalHandler());
         $this->assertTrue($executed);
     }
 
@@ -314,7 +332,7 @@ class MiddlewarePipeTest extends TestCase
         $uri     = (new Uri())->withPath($path);
         $request = (new Request)->withUri($uri);
 
-        $response = $middleware($request, $this->response);
+        $response = $middleware($request, $this->response, $this->createFinalHandler());
         $this->assertTrue($response->hasHeader('x-found'));
     }
 
@@ -440,7 +458,7 @@ class MiddlewarePipeTest extends TestCase
 
         $uri      = (new Uri())->withPath($fullPath);
         $request  = (new Request)->withUri($uri);
-        $response = $middleware($request, $this->response);
+        $response = $middleware($request, $this->response, $this->createFinalHandler());
         $this->$assertion(
             $response->hasHeader('X-Found'),
             sprintf(
@@ -470,6 +488,7 @@ class MiddlewarePipeTest extends TestCase
      */
     public function testPassesOriginalResponseToFinalHandler()
     {
+        $this->suppressDeprecationNotice();
         $request  = new Request([], [], 'http://local.example.com/foo', 'GET', 'php://memory');
         $response = new Response();
         $test     = new Response();
@@ -483,5 +502,31 @@ class MiddlewarePipeTest extends TestCase
         // original.
         $result = $pipeline($request, $response);
         $this->assertSame($test, $result);
+    }
+
+    public function testOmittingFinalHandlerDuringInvocationRaisesDeprecationNotice()
+    {
+        $request   = new Request([], [], 'http://local.example.com/foo', 'GET', 'php://memory');
+        $response  = new Response();
+        $triggered = false;
+
+        $this->deprecationsSuppressed = set_error_handler(function ($errno, $errstr) use (&$triggered) {
+            $this->assertContains(MiddlewarePipe::class . '()', $errstr);
+            $triggered = true;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        $pipeline = new MiddlewarePipe();
+        $pipeline->pipe(function ($req, $res, $next) {
+            $res->write('Some content');
+            return $res->withStatus(201);
+        });
+
+        $result = $pipeline($request, $response);
+
+        $this->assertNotSame($response, $result);
+        $this->assertEquals(201, $result->getStatusCode());
+        $this->assertEquals('Some content', (string) $result->getBody());
+        $this->assertTrue($triggered, 'Error handler was not triggered');
     }
 }

--- a/test/NoopFinalHandlerTest.php
+++ b/test/NoopFinalHandlerTest.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stratigility;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Stratigility\NoopFinalHandler;
+
+class NoopFinalHandlerTest extends TestCase
+{
+    public function testHandlerReturnsResponseProvidedAtInvocation()
+    {
+        $handler  = new NoopFinalHandler();
+        $request  = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $this->assertSame($response, $handler($request, $response));
+    }
+}


### PR DESCRIPTION
This patch will provide the forwards compatibility features for the next minor version of Stratigility that implement the [RFC on FinalHandler and ErrorMiddlewareInterface removal](https://gist.github.com/weierophinney/db0a5b1d2d8ec1b8871e9ebb72a4091c).

- [x] Create NotFoundHandler and ErrorHandler middleware
    - `NotFoundHandler` returns a basic 404 response, always.
    - `ErrorHandler`:
        - creates a PHP error handler that will throw any errors not in the current `error_handler` mask as `ErrorExceptions`.
        - Does a try/catch around `$next()`
        - Raises a new exception, `MissingResponseException`, if `$next` does not return a response.
        - Casts all `Throwable`/`Exception` items to error responses:
            - If a boolean true flag is passed to the constructor, it will use the stack trace in the response.
            - Triggers listeners on the instance with the exception/throwable, request, and response, for reporting purposes.
- [x] Create a no-op final handler that returns the provided response on invocation, ignoring all other arguments.
- [x] Update `MiddlewarePipe` to issue a deprecation notice if `$out` is omitted.
- [x] Mark `Dispatch` as deprecated.
- [x] Update `Next` to raise deprecation notice when receiving a non-null `$err` argument.
- [x] Mark `FinalHandler` as deprecated.
- [x] Mark `ErrorMiddlewareInterface` as deprecated.
- [x] Write migration guide.

Notes
-----

- In order to return a response, each new middleware type (`NotFoundHandler`, `ErrorHandler`) accepts a prototype `ResponseInterface` instance to the constructor; this is then used to generate the returned response in 404/error conditions. This is done to allow re-use with any PSR-7 implementation.