### PR TITLE
Deprecate Http subnamespace

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -20,7 +20,8 @@ use Psr\Http\Message\UriInterface;
  * manipulate arbitrary instance members.
  *
  * @deprecated since 1.3.0; to be removed with 2.0.0. Track the original
- *     request via a request attribute or via a service instead.
+ *     request via a request attribute or via a service instead; you can
+ *     use Zend\Stratigility\Middleware\OriginalMessages to do so.
  */
 class Request implements ServerRequestInterface
 {
@@ -53,7 +54,9 @@ class Request implements ServerRequestInterface
         }
 
         $this->originalRequest = $originalRequest;
-        $this->psrRequest      = $decoratedRequest->withAttribute('originalUri', $originalRequest->getUri());
+        $this->psrRequest      = $decoratedRequest
+            ->withAttribute('originalUri', $originalRequest->getUri())
+            ->withAttribute('originalRequest', $originalRequest);
     }
 
     /**

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -18,6 +18,9 @@ use Psr\Http\Message\UriInterface;
  *
  * Decorates the PSR incoming request interface to add the ability to
  * manipulate arbitrary instance members.
+ *
+ * @deprecated since 1.3.0; to be removed with 2.0.0. Track the original
+ *     request via a request attribute or via a service instead.
  */
 class Request implements ServerRequestInterface
 {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -66,6 +66,16 @@ class Request implements ServerRequestInterface
      */
     public function getCurrentRequest()
     {
+        trigger_error(sprintf(
+            '%s is now deprecated. The request passed to your method is the current '
+            . 'request now. %s will no longer be available starting in Stratigility 2.0.0. '
+            . 'Please see https://docs.zendframework.com/migration/to-v2/#original-request-response-and-uri '
+            . 'for full details.',
+            __CLASS__,
+            \Zend\Stratigility\Middleware\OriginalMessages::class,
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->psrRequest;
     }
 
@@ -76,6 +86,17 @@ class Request implements ServerRequestInterface
      */
     public function getOriginalRequest()
     {
+        trigger_error(sprintf(
+            '%s is now deprecated. Please register %s as your outermost middleware, '
+            . 'and pull the original request via the request "originalRequest" '
+            . 'attribute. %s will no longer be available starting in Stratigility 2.0.0. '
+            . 'Please see https://docs.zendframework.com/migration/to-v2/#original-request-response-and-uri '
+            . 'for full details.',
+            __CLASS__,
+            \Zend\Stratigility\Middleware\OriginalMessages::class,
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->originalRequest;
     }
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -20,8 +20,9 @@ use Psr\Http\Message\StreamInterface;
  * to provide a common interface for all PSR HTTP implementations.
  *
  * @deprecated since 1.3.0; to be removed with 2.0.0. Track the original
- *     response via a request attribute or via a service instead; use
- *     only the methods defined in PSR-7.
+ *     response via a request attribute or via a service instead; you
+ *     can use Zend\Stratigility\Middleware\OriginalMessages to do so. We
+ *     recommend that you use only the methods defined in PSR-7.
  */
 class Response implements
     PsrResponseInterface,

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -18,6 +18,10 @@ use Psr\Http\Message\StreamInterface;
  *
  * Adds in write, end, and isComplete from RequestInterface in order
  * to provide a common interface for all PSR HTTP implementations.
+ *
+ * @deprecated since 1.3.0; to be removed with 2.0.0. Track the original
+ *     response via a request attribute or via a service instead; use
+ *     only the methods defined in PSR-7.
  */
 class Response implements
     PsrResponseInterface,

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -53,6 +53,16 @@ class Response implements
      */
     public function getOriginalResponse()
     {
+        trigger_error(sprintf(
+            '%s is now deprecated. Please register %s as your outermost middleware, '
+            . 'and pull the original response via the request "originalResponse" '
+            . 'attribute. %s will no longer be available starting in Stratigility 2.0.0. '
+            . 'Please see https://docs.zendframework.com/migration/to-v2/#original-request-response-and-uri '
+            . 'for full details.',
+            __CLASS__,
+            \Zend\Stratigility\Middleware\OriginalMessages::class,
+            __METHOD__
+        ), E_USER_DEPRECATED);
         return $this->psrResponse;
     }
 
@@ -67,6 +77,15 @@ class Response implements
      */
     public function write($data)
     {
+        trigger_error(sprintf(
+            '%s is now deprecated; use $response->getBody()->write(). '
+            . '%s will no longer be available starting in Stratigility 2.0.0. '
+            . 'Please see https://docs.zendframework.com/migration/to-v2/#deprecated-functionality '
+            . 'for full details.',
+            __CLASS__,
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if ($this->complete) {
             throw $this->responseIsAlreadyCompleted(__METHOD__);
         }
@@ -89,6 +108,15 @@ class Response implements
      */
     public function end($data = null)
     {
+        trigger_error(sprintf(
+            '%s is now deprecated; use $response->getBody()->write(). '
+            . '%s will no longer be available starting in Stratigility 2.0.0. '
+            . 'Please see https://docs.zendframework.com/migration/to-v2/#deprecated-functionality '
+            . 'for full details.',
+            __CLASS__,
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if ($this->complete) {
             return $this;
         }
@@ -111,6 +139,15 @@ class Response implements
      */
     public function isComplete()
     {
+        trigger_error(sprintf(
+            '%s is now deprecated; use $response->getBody()->write(). '
+            . '%s will no longer be available starting in Stratigility 2.0.0. '
+            . 'Please see https://docs.zendframework.com/migration/to-v2/#deprecated-functionality '
+            . 'for full details.',
+            __CLASS__,
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->complete;
     }
 

--- a/src/Http/ResponseInterface.php
+++ b/src/Http/ResponseInterface.php
@@ -17,6 +17,9 @@ namespace Zend\Stratigility\Http;
  * - Write to the content
  * - End the response (mark it complete)
  * - Determine if the response is complete
+ *
+ * @deprecated since 1.3.0; to be removed with 2.0.0. Do not use the methods
+ *     defined in this interface; use only those defined in PSR-7.
  */
 interface ResponseInterface
 {

--- a/src/Middleware/OriginalMessages.php
+++ b/src/Middleware/OriginalMessages.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Stratigility\MiddlewareInterface;
+
+/**
+ * Inject attributes containing the original request, response, and URI instances.
+ *
+ * This middleware will add request attributes as follows:
+ *
+ * - "originalRequest", representing the request provided to this middleware.
+ * - "originalResponse", representing the response provided to this middleware.
+ * - "originalUri", representing the URI composed by the request provided to
+ *   this middleware.
+ *
+ * These can then be reference later, for tasks such as:
+ *
+ * - Determining the base path when generating a URI (as layers may receive
+ *   URIs stripping path segments).
+ * - Determining if changes to the response have occurred.
+ * - Providing prototypes for factories.
+ */
+class OriginalMessages implements MiddlewareInterface
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @param null|callable $next
+     * @return ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next = null)
+    {
+        if (! $next) {
+            return $response;
+        }
+
+        $request = $request
+            ->withAttribute('originalUri', $request->getUri())
+            ->withAttribute('originalRequest', $request)
+            ->withAttribute('originalResponse', $response);
+
+        return $next($request, $response);
+    }
+}

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -16,11 +16,32 @@ use Zend\Stratigility\Http\Request;
 
 class RequestTest extends TestCase
 {
+    public $errorHandler;
+
     public function setUp()
     {
+        $this->restoreErrorHandler();
+        $this->errorHandler = function ($errno, $errstr) {
+            return (false !== strstr($errstr, Request::class . ' is now deprecated'));
+        };
+        set_error_handler($this->errorHandler, E_USER_DEPRECATED);
+
         $psrRequest     = new PsrRequest([], [], 'http://example.com/', 'GET', 'php://memory');
         $this->original = $psrRequest;
         $this->request  = new Request($this->original);
+    }
+
+    public function tearDown()
+    {
+        $this->restoreErrorHandler();
+    }
+
+    public function restoreErrorHandler()
+    {
+        if ($this->errorHandler) {
+            restore_error_handler();
+            $this->errorHandler = null;
+        }
     }
 
     public function testCallingSetUriSetsUriInRequestAndOriginalRequestInClone()

--- a/test/Http/ResponseTest.php
+++ b/test/Http/ResponseTest.php
@@ -17,10 +17,31 @@ use Zend\Stratigility\Http\Response;
 
 class ResponseTest extends TestCase
 {
+    public $errorHandler;
+
     public function setUp()
     {
+        $this->restoreErrorHandler();
+        $this->errorHandler = function ($errno, $errstr) {
+            return (false !== strstr($errstr, Response::class . ' is now deprecated'));
+        };
+        set_error_handler($this->errorHandler, E_USER_DEPRECATED);
+
         $this->original = new PsrResponse();
         $this->response = new Response($this->original);
+    }
+
+    public function tearDown()
+    {
+        $this->restoreErrorHandler();
+    }
+
+    public function restoreErrorHandler()
+    {
+        if ($this->errorHandler) {
+            restore_error_handler();
+            $this->errorHandler = null;
+        }
     }
 
     public function testIsNotCompleteByDefault()

--- a/test/Middleware/OriginalMessagesTest.php
+++ b/test/Middleware/OriginalMessagesTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stratigility\Middleware;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+use Zend\Stratigility\Middleware\OriginalMessages;
+
+class OriginalMessagesTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->uri = $this->prophesize(UriInterface::class);
+        $this->request = $this->prophesize(ServerRequestInterface::class);
+        $this->response = $this->prophesize(ResponseInterface::class);
+    }
+
+    public function testNotPassingNextArgumentReturnsResponseVerbatim()
+    {
+        $middleware = new OriginalMessages();
+
+        $this->request->getUri()->shouldNotBeCalled();
+        $response = $middleware(
+            $this->request->reveal(),
+            $this->response->reveal()
+        );
+
+        $this->assertSame($this->response->reveal(), $response);
+    }
+
+    public function testNextReceivesRequestWithNewAttributes()
+    {
+        $middleware = new OriginalMessages();
+        $expected   = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($request, $response) use ($expected) {
+            return $expected;
+        };
+
+        $this->request->getUri()->will([$this->uri, 'reveal']);
+        $this->request->withAttribute(
+            'originalUri',
+            Argument::that(function ($arg) {
+                $this->assertSame($this->uri->reveal(), $arg);
+                return $arg;
+            })
+        )->will([$this->request, 'reveal']);
+
+        $this->request->withAttribute(
+            'originalRequest',
+            Argument::that(function ($arg) {
+                $this->assertSame($this->request->reveal(), $arg);
+                return $arg;
+            })
+        )->will([$this->request, 'reveal']);
+
+        $this->request->withAttribute(
+            'originalResponse',
+            Argument::that(function ($arg) {
+                $this->assertSame($this->response->reveal(), $arg);
+                return $arg;
+            })
+        )->will([$this->request, 'reveal']);
+
+        $response = $middleware(
+            $this->request->reveal(),
+            $this->response->reveal(),
+            $next
+        );
+
+        $this->assertSame($expected, $response);
+    }
+}

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -150,7 +150,7 @@ class NextTest extends TestCase
             $next($req, $res);
         });
         $route3 = new Route('/foo/baz', function ($req, $res, $next) {
-            $res->end('done');
+            $res->getBody()->write('done');
             return $res;
         });
 


### PR DESCRIPTION
Per the [RFC on removing the request and response decorators](https://gist.github.com/weierophinney/ecbd2ba572600a1bfc86840b4cfeca6b), this patch deprecates them for the upcoming 1.3 release.

The following changes were made:

Deprecated
----------

- `Zend\Stratigility\Http\Request`
  - The "psr" request is now injected with an additional attribute, `originalRequest`, allowing retrieval using standard PSR-7 methods.
  - Additionally, the methods `getCurrentRequest()` and `getOriginalRequest()` now emit deprecation notices.
- `Zend\Stratigility\Http\ResponseInterface`
  - Additionally, the methods `write()`, `end()`, `isComplete()`, and `getOriginalResponse()` now emit deprecation notices.
- `Zend\Stratigility\Http\Response`

Changed
-------

- `Zend\Stratigility\FinalHandler`
  - now pulls the original request via the `originalRequest` attribute instead.
  - no longer decorates the response, and instead writes to the PSR-7 response body directly (vs via the response `write()` method).

Added
-----

- `Zend\Stratigility\Middleware\OriginalMessages` is middleware that will inject the request instance passed to deeper layers with three attributes:
  - `originalRequest`, representing the request provided to it
  - `originalResponse`, representing the response provided to it
  - `originalUri`, representing the URI composed by the request provided to it
  We now recommend that if you need any of these artifacts, you pipe this middleware as the first layer of your application.