### PR TITLE
Remove aliases for PSR-7 interfaces from MiddlewareInterface

### DIFF
--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -9,8 +9,8 @@
 
 namespace Zend\Stratigility;
 
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Middleware.
@@ -49,10 +49,10 @@ interface MiddlewareInterface
      * Often, middleware will `return $out();`, with the assumption that a
      * later middleware will return a response.
      *
-     * @param Request $request
-     * @param Response $response
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      * @param null|callable $out
      * @return null|Response
      */
-    public function __invoke(Request $request, Response $response, callable $out = null);
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $out = null);
 }


### PR DESCRIPTION
I propose to remove the `MiddlewareInterface` aliases for the PSR-7 interfaces. Its super annoying that most of the PSR-7 implementations (including diactoros) use `Response` as class name, then you have either to alias the Response implementation with something else or remove this aliases manually from your middleware (Considering they were automatically imported by your IDE when you implemented the `MiddlewareInterface`).

If you think about it, it adds no benefit, because in reality what is being expected there is a instance for the interface, so there is no benefit of hiding it in the arguments. On the other side, variable name makes sense, since you'll be receiving a concrete.  