### PR TITLE
Allow opt-in to raising exceptions instead of error middleware

### DIFF
--- a/doc/book/error-handlers.md
+++ b/doc/book/error-handlers.md
@@ -11,6 +11,8 @@ You can typically handle these conditions via middleware itself.
 
 ## Handling 404 conditions
 
+- Since 1.3.0
+
 If no middleware is able to handle the incoming request, this is typically
 representative of an HTTP 404 status. Stratigility provides a barebones
 middleware that you may register in an innermost layer that will return a 404
@@ -63,6 +65,27 @@ class NotFoundMiddleware implements ServerMiddlewareInterface
 ```
 
 ## Handling PHP errors and exceptions
+
+- Since 1.3.0
+
+> ### Opting in to error middleware
+>
+> If you have upgraded from Expressive 1.0.0, you will have been using the
+> `FinalHandler` implementation, and relying on the fact that, internally,
+> dispatching wraps all middleware in `try/catch` blocks.
+> 
+> Starting in 1.3.0, we provide a new way to handle errors via middleware.
+> 
+> **To opt-in to the new system, you must call `raiseThrowables()` on your
+> middleware pipeline:**
+> 
+> ```php
+> $pipeline = new MiddlewarePipe();
+> $pipeline->raiseThrowables();
+> ```
+> 
+> (Starting in 2.0.0, this will no longer be necessary, but until then, this is
+> how you opt-in to the system described below.)
 
 `Zend\Stratigility\Middleware\ErrorHandler` is a middleware implementation to
 register as the *outermost layer* of your application (or close to the outermost

--- a/doc/book/migration/to-v2.md
+++ b/doc/book/migration/to-v2.md
@@ -79,8 +79,17 @@ These approaches, however, have several shortcomings:
 Starting in 1.3, we are promoting using standard middleware layers as error
 handlers, instead of using the existing error middleware/final handler system.
 
-To achieve this, we have provided some new functionality, as well as augmented
-existing functionality:
+The first step is to opt-in to having throwables and exceptions raised by
+middleware, instead of having the dispatcher catch them and then invoke
+middleware. Do this via the `MiddlewarePipe::raiseThrowables()` method:
+
+```php
+$pipeline = new MiddlewarePipe();
+$pipeline->raiseThrowables();
+```
+
+Once you have done that you may start using some of the new functionality, as
+well as augmented existing functionality:
 
 - [NotFoundHandler middleware](../error-handlers.md#handling-404-conditions)
 - [ErrorHandler middleware](../error-handlers.md#handling-php-errors-and-exceptions)
@@ -133,6 +142,8 @@ request and a response, and be guaranteed to return a response instance.)
 
 To summarize:
 
+- Call the `raiseThrowables()` method of your `MiddlewarePipe` instance to
+  opt-in to the new error handling strategy.
 - Use the new `Zend\Stratigility\Middleware\NotFoundHandler` as the innermost
   layer of your application pipeline in order to provide 404 responses.
 - Use the new `Zend\Stratigility\Middleware\ErrorHandler` middleware as the

--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Stratigility;
 
-use Interop\Http\Middleware\DelegateInterface;
 use Interop\Http\Middleware\MiddlewareInterface as InteropMiddlewareInterface;
 use Interop\Http\Middleware\ServerMiddlewareInterface;
 use Throwable;

--- a/src/Exception/MiddlewareException.php
+++ b/src/Exception/MiddlewareException.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stratigility\Exception;
+
+use RuntimeException;
+
+/**
+ * Exception raised when a string $err is provided and raise throwables is enabled.
+ *
+ * @todo Remove for 2.0.0.
+ */
+class MiddlewareException extends RuntimeException
+{
+    /**
+     * Create an instance based on an error value.
+     *
+     * @param mixed $err
+     * @return self
+     */
+    public static function fromErrorValue($err)
+    {
+        if (is_object($err)) {
+            return self::fromType(get_class($err));
+        }
+
+        if (is_array($err)) {
+            return self::fromType(gettype($err));
+        }
+
+        if (is_string($err)) {
+            throw new self($err);
+        }
+
+        return self::fromType(var_export($err, true));
+    }
+
+    /**
+     * Create an instance using a templated error string.
+     *
+     * @param string $value
+     * @return self
+     */
+    private static function fromType($value)
+    {
+        return new self(sprintf(
+            'Middleware raised an error condition: %s',
+            $value
+        ));
+    }
+}


### PR DESCRIPTION
This patch implements the features suggested in #77. Specifically, it adds a "raise throwables" flag that may be set on each of the `MiddlewarePipe`, `Next`, and `Dispatch` instances; setting it on one enables it on each layer deeper:

- Setting it on `Dispatch` only enables it on that instance.
- Setting it on `Next` also enables it on `Dispatch`.
- Setting it on `MiddlewarePipe` also enables it on `Next` and `Dispatch`.

The flag is toggled off by default (current 1.0 behavior), and cannot be disabled once enabled.

Once enabled:

- `Dispatch` will not wrap middleware dispatch in a try/catch block.
- `Next`, when presented with an `$err` argument will:
  - throw the argument, if throwable.
  - raise a deprecation notice otherwise, and then create a `Zend\Stratigility\Exception\MiddlewareException` based on the `$err` value.
- `MiddlewarePipe` will enable the flag on `Next` instances it creates (and thus the `Dispatch` instances).

The end result is that, if enabled on the outermost application pipeline, you will now have the 2.0 error handling mechanism in place: middleware raises exceptions, and outer middleware catches these and does something with them.

This feature will allow Expressive, for instance, to opt-in to the feature in the next minor version, while providing default error handling mimicing what it already provides via the `FinalHandler` implementation, *without breaking backwards compatibility*.