### PR TITLE
Only support ServerMiddlewareInterface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
     - php: 7
       env:
         - TEST_COVERAGE=true
+    - php: 7.1
     - php: hhvm 
   allow_failures:
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ cache:
 
 env:
   global:
-    - SITE_URL: https://zendframework.github.io/zend-stratigility
-    - GH_USER_NAME: "Matthew Weier O'Phinney"
-    - GH_USER_EMAIL: matthew@weierophinney.net
-    - GH_REF: github.com/zendframework/zend-stratigility.git
+    - SITE_URL=https://zendframework.github.io/zend-stratigility
+    - GH_USER_NAME="Matthew Weier O'Phinney"
+    - GH_USER_EMAIL=matthew@weierophinney.net
+    - GH_REF=github.com/zendframework/zend-stratigility.git
     - secure: "XIgjYGyiogFeDNIbwrqoNif8ui7SEcmjhu5EchtLB6F84D9WWQ8LWwqB6PC4aeF4w4kgHmEUthqutX3VYOnNEHGL0zNVMyjlYQ2aQZUQMo53Lui/fIWZQbZIeVC/1AwZ/GOVdoLljvqHNlpDMM38DlGCmnlWzU9f58UtPefjfZ2e0emX4uERJODoQaIH4MqYC2YyGFVK8ki/IQAXa70tVGQqysciz1mhVHUhHJpb+EhJAlmxdh7bVg8hcgKHovPjYDcsJgHyG7/k71pLHun7FcpzGyx97iTJSqiEEQuRi01N3wHY9NOqK6XltV3klBwensrN/t7QiEmrupgAggog3yO9uiN18MkKuszGOGehXa5xKLYfpJzxq+jfwsv13gxiWqTU1DK8FtxcH5OH8168FkFF/UEzSBraFwYPI9KmfZ8BnoIXBvLnFf51clGH63dccd11Q51WxSF4+0v4ddovb/onRnVOZC0Qo3kJE00eg7k0h8A0AjgzwG88L1dZq6JlIHWAEPRonVxp1UI8ufGv0ZToZoG8ZBh+trKiRHnlO32N7fmRd3/inbd58+JTb3yMw8cH8l85dp2s0Vcp/xdW+2JYXrMXhF4SF0HBa8p4pqzIWR1n35RtHHuFUoac8e2rBkIBHmOW3puc+STLA+057zFo5T7U+hSoTK7LrTW8UU4="
 
 matrix:

--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Stratigility;
 
-use Interop\Http\Middleware\MiddlewareInterface as InteropMiddlewareInterface;
 use Interop\Http\Middleware\ServerMiddlewareInterface;
 use Throwable;
 use Psr\Http\Message\RequestInterface;
@@ -77,7 +76,7 @@ class Dispatch
             $this->setResponsePrototype($response);
         }
 
-        if ($this->isInteropMiddleware($route->handler)) {
+        if ($route->handler instanceof ServerMiddlewareInterface) {
             return $this->dispatchInteropMiddleware($route->handler, $next, $request);
         }
 
@@ -133,18 +132,6 @@ class Dispatch
     }
 
     /**
-     * Test if the middleware composed by a route is http-interop middleware.
-     *
-     * @param mixed $handler
-     * @return bool
-     */
-    private function isInteropMiddleware($handler)
-    {
-        return $handler instanceof ServerMiddlewareInterface
-            || $handler instanceof InteropMiddlewareInterface;
-    }
-
-    /**
      * Test if the middleware composed by a route is not http-interop middleware.
      *
      * @param mixed $handler
@@ -157,7 +144,7 @@ class Dispatch
      */
     private function isNotInteropMiddleware($handler, RequestInterface $request)
     {
-        if ($this->isInteropMiddleware($handler)) {
+        if ($handler instanceof ServerMiddlewareInterface) {
             return false;
         }
 
@@ -243,7 +230,7 @@ class Dispatch
     /**
      * Dispatch http-interop middleware
      *
-     * @param ServerMiddlewareInterface|InteropMiddlewareInterface $middleware
+     * @param ServerMiddlewareInterface $middleware
      * @param callable $next
      * @param RequestInterface $request
      * @return ResponseInterface
@@ -252,8 +239,11 @@ class Dispatch
      * @throws Exception\InvalidRequestTypeException if the request provided
      *     is not a server-side request.
      */
-    private function dispatchInteropMiddleware($middleware, callable $next, RequestInterface $request)
-    {
+    private function dispatchInteropMiddleware(
+        ServerMiddlewareInterface $middleware,
+        callable $next,
+        RequestInterface $request
+    ) {
         if ($middleware instanceof MiddlewarePipe
             && ! $middleware->hasResponsePrototype()
             && $this->responsePrototype

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -11,7 +11,6 @@ namespace Zend\Stratigility;
 
 use Closure;
 use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\MiddlewareInterface as InteropMiddlewareInterface;
 use Interop\Http\Middleware\ServerMiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -285,8 +284,7 @@ class MiddlewarePipe implements MiddlewareInterface, ServerMiddlewareInterface
     private function isValidMiddleware($middleware)
     {
         return is_callable($middleware)
-            || $middleware instanceof ServerMiddlewareInterface
-            || $middleware instanceof InteropMiddlewareInterface;
+            || $middleware instanceof ServerMiddlewareInterface;
     }
 
     /**
@@ -298,8 +296,7 @@ class MiddlewarePipe implements MiddlewareInterface, ServerMiddlewareInterface
     private function isInteropMiddleware($middleware)
     {
         return ! is_callable($middleware)
-            && ($middleware instanceof ServerMiddlewareInterface
-                || $middleware instanceof InteropMiddlewareInterface);
+            && $middleware instanceof ServerMiddlewareInterface;
     }
 
     /**

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Stratigility;
 
 use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\MiddlewareInterface;
 use Interop\Http\Middleware\ServerMiddlewareInterface;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
@@ -594,24 +593,15 @@ class MiddlewarePipeTest extends TestCase
         $this->assertAttributeSame($response, 'responsePrototype', $pipeline);
     }
 
-    public function interopMiddleware()
-    {
-        return [
-            MiddlewareInterface::class => [MiddlewareInterface::class],
-            ServerMiddlewareInterface::class => [ServerMiddlewareInterface::class],
-        ];
-    }
-
     /**
      * @group http-interop
-     * @dataProvider interopMiddleware
      */
-    public function testCanPipeInteropMiddleware($middlewareType)
+    public function testCanPipeInteropMiddleware()
     {
         $delegate = $this->prophesize(DelegateInterface::class)->reveal();
 
         $response = $this->prophesize(ResponseInterface::class);
-        $middleware = $this->prophesize($middlewareType);
+        $middleware = $this->prophesize(ServerMiddlewareInterface::class);
         $middleware
             ->process(Argument::type(RequestInterface::class), Argument::type(DelegateInterface::class))
             ->will([$response, 'reveal']);


### PR DESCRIPTION
Per http-interop/http-middleware#27, `MiddlewareInterface` will no longer be included in http-interop in subsequent versions. As such, we can simplify our logic in a number of locations.