### PR TITLE
Ensure Next processes the next delegate correctly when an error is present

### DIFF
--- a/src/Next.php
+++ b/src/Next.php
@@ -396,7 +396,9 @@ class Next implements DelegateInterface
         ResponseInterface $response = null,
         $err = null
     ) {
-        if ($nextDelegate instanceof DelegateInterface) {
+        if ($nextDelegate instanceof DelegateInterface
+            && (! $nextDelegate instanceof Next || $err === null)
+        ) {
             return $nextDelegate->process($request);
         }
 

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -639,6 +639,27 @@ class MiddlewarePipeTest extends TestCase
     }
 
     /**
+     * @group http-interop
+     */
+    public function testWillNotDecorateCallableMiddlewareAsInteropMiddlewareIfResponsePrototypeIsNotPresent()
+    {
+        $pipeline = new MiddlewarePipe();
+
+        $middleware = function () {
+        };
+        $pipeline->pipe($middleware);
+
+        $r = new ReflectionProperty($pipeline, 'pipeline');
+        $r->setAccessible(true);
+        $queue = $r->getValue($pipeline);
+
+        $route = $queue->dequeue();
+        $test = $route->handler;
+        $this->assertNotInstanceOf(CallableMiddlewareWrapper::class, $test);
+        $this->assertInternalType('callable', $test);
+    }
+
+    /**
      * @todo Remove with 2.0.0
      */
     public function errorMiddleware()


### PR DESCRIPTION
Discovered when updating tests for Expressive to work with Stratigility 1.3. Essentially, when nesting pipelines, if an inner middleware pipeline is exhausted and a non-null `$err` is present, if the next delegate was a `Next` instance, it was improperly being called as an http-interop `DelegateInterface`, losing the error argument. As such, if any parent delegate contained error middleware, that middleware would never be invoked.

This may be related to #84.