### PR TITLE
Hotfix - deprecated messages - link to migration guide

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -69,7 +69,8 @@ class Request implements ServerRequestInterface
         trigger_error(sprintf(
             '%s is now deprecated. The request passed to your method is the current '
             . 'request now. %s will no longer be available starting in Stratigility 2.0.0. '
-            . 'Please see https://docs.zendframework.com/migration/to-v2/#original-request-response-and-uri '
+            . 'Please see '
+            . 'https://docs.zendframework.com/zend-stratigility/migration/to-v2/#original-request-response-and-uri '
             . 'for full details.',
             __CLASS__,
             \Zend\Stratigility\Middleware\OriginalMessages::class,
@@ -90,7 +91,8 @@ class Request implements ServerRequestInterface
             '%s is now deprecated. Please register %s as your outermost middleware, '
             . 'and pull the original request via the request "originalRequest" '
             . 'attribute. %s will no longer be available starting in Stratigility 2.0.0. '
-            . 'Please see https://docs.zendframework.com/migration/to-v2/#original-request-response-and-uri '
+            . 'Please see '
+            . 'https://docs.zendframework.com/zend-stratigility/migration/to-v2/#original-request-response-and-uri '
             . 'for full details.',
             __CLASS__,
             \Zend\Stratigility\Middleware\OriginalMessages::class,

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -57,7 +57,8 @@ class Response implements
             '%s is now deprecated. Please register %s as your outermost middleware, '
             . 'and pull the original response via the request "originalResponse" '
             . 'attribute. %s will no longer be available starting in Stratigility 2.0.0. '
-            . 'Please see https://docs.zendframework.com/migration/to-v2/#original-request-response-and-uri '
+            . 'Please see '
+            . 'https://docs.zendframework.com/zend-stratigility/migration/to-v2/#original-request-response-and-uri '
             . 'for full details.',
             __CLASS__,
             \Zend\Stratigility\Middleware\OriginalMessages::class,
@@ -80,7 +81,8 @@ class Response implements
         trigger_error(sprintf(
             '%s is now deprecated; use $response->getBody()->write(). '
             . '%s will no longer be available starting in Stratigility 2.0.0. '
-            . 'Please see https://docs.zendframework.com/migration/to-v2/#deprecated-functionality '
+            . 'Please see '
+            . 'https://docs.zendframework.com/zend-stratigility/migration/to-v2/#deprecated-functionality '
             . 'for full details.',
             __CLASS__,
             __METHOD__
@@ -111,7 +113,8 @@ class Response implements
         trigger_error(sprintf(
             '%s is now deprecated; use $response->getBody()->write(). '
             . '%s will no longer be available starting in Stratigility 2.0.0. '
-            . 'Please see https://docs.zendframework.com/migration/to-v2/#deprecated-functionality '
+            . 'Please see '
+            . 'https://docs.zendframework.com/zend-stratigility/migration/to-v2/#deprecated-functionality '
             . 'for full details.',
             __CLASS__,
             __METHOD__
@@ -142,7 +145,8 @@ class Response implements
         trigger_error(sprintf(
             '%s is now deprecated; use $response->getBody()->write(). '
             . '%s will no longer be available starting in Stratigility 2.0.0. '
-            . 'Please see https://docs.zendframework.com/migration/to-v2/#deprecated-functionality '
+            . 'Please see '
+            . 'https://docs.zendframework.com/zend-stratigility/migration/to-v2/#deprecated-functionality '
             . 'for full details.',
             __CLASS__,
             __METHOD__


### PR DESCRIPTION
There are wrong links to migration guide in deprecated error messages.
There should be:
`https://docs.zendframework.com/zend-stratigility/migration/to-v2/#original-request-response-and-uri`
instead of:
`https://docs.zendframework.com/migration/to-v2/#original-request-response-and-uri`

(so there is missing `/zend-stratigility` in the path).