### PR TITLE
Contributing guide fixes + zend-coding-standard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,13 +63,13 @@ To run tests:
 
   If you don't have `curl` installed, you can also download `composer.phar` from https://getcomposer.org/
 
-- Run the tests via `phpunit` and the provided PHPUnit config, like in this example:
+- Run the tests using the "test" command shipped in the `composer.json`:
 
   ```console
-  $ ./vendor/bin/phpunit
+  $ composer test
   ```
 
-You can turn on conditional tests with the phpunit.xml file.
+You can turn on conditional tests with the `phpunit.xml` file.
 To do so:
 
  -  Copy `phpunit.xml.dist` file to `phpunit.xml`
@@ -78,24 +78,22 @@ To do so:
 
 ## Running Coding Standards Checks
 
-This component uses [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) for coding
-standards checks, and provides configuration for our selected checks.
-`phpcs` is installed by default via Composer.
+First, ensure you've installed dependencies via composer, per the previous
+section on running tests.
 
-To run checks only:
-
-```console
-$ ./vendor/bin/phpcs
-```
-
-`phpcs` also installs a tool named `phpcbf` which can attempt to fix problems
-for you:
+To run CS checks only:
 
 ```console
-$ ./vendor/bin/phpcbf
+$ composer cs-check
 ```
 
-If you allow phpcbf to fix CS issues, please re-run the tests to ensure
+To attempt to automatically fix common CS issues:
+
+```console
+$ composer cs-fix
+```
+
+If the above fixes any CS issues, please re-run the tests to ensure
 they pass, and make sure you add and commit the changes after verification.
 
 ## Recommended Workflow for Contributions

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   "require-dev": {
     "zendframework/zend-diactoros": "^1.0",
     "phpunit/phpunit": "^5.6",
-    "squizlabs/php_codesniffer": "^2.7"
+    "zendframework/zend-coding-standard": "~1.0.0"
   },
   "suggest": {
     "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Stratigility; e.g., zendframework/zend-diactoros"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "894106948db77b28e333bf0b605fd1cf",
-    "content-hash": "3f7510f11995eb6034e908bebe33cec7",
+    "hash": "2c7f26fd1c911205382aaf7bde89a73a",
+    "content-hash": "cbf247339c2c5e52306e4fa8f027ba09",
     "packages": [
         {
             "name": "http-interop/http-middleware",
@@ -1533,6 +1533,35 @@
                 "validate"
             ],
             "time": "2016-08-09 15:02:57"
+        },
+        {
+            "name": "zendframework/zend-coding-standard",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-coding-standard.git",
+                "reference": "893316d2904e93f1c74c1384b6d7d57778299cb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-coding-standard/zipball/893316d2904e93f1c74c1384b6d7d57778299cb6",
+                "reference": "893316d2904e93f1c74c1384b6d7d57778299cb6",
+                "shasum": ""
+            },
+            "require": {
+                "squizlabs/php_codesniffer": "^2.7"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Zend Framework coding standard",
+            "keywords": [
+                "Coding Standard",
+                "zf"
+            ],
+            "time": "2016-11-09 21:30:43"
         },
         {
             "name": "zendframework/zend-diactoros",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,25 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="Zend Framework coding standard">
-    <description>Zend Framework coding standard</description>
-
-    <!-- display progress -->
-    <arg value="p"/>
-    <arg name="colors"/>
-
-    <!-- inherit rules from: -->
-    <rule ref="PSR2"/>
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-    <rule ref="Generic.Formatting.SpaceAfterNot"/>
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
-        <properties>
-            <property name="ignoreNewlines" value="true"/>
-        </properties>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
-        <properties>
-            <property name="ignoreBlankLines" value="false"/>
-        </properties>
-    </rule>
+<ruleset name="Zend Framework Coding Standard">
+    <rule ref="./vendor/zendframework/zend-coding-standard/ruleset.xml"/>
 
     <!-- Paths to check -->
     <file>src</file>


### PR DESCRIPTION
- Updated contributing guide to refer composer scripts.
- Switched to `zend-coding-standard` library (~1.0.0)