### PR TITLE
Updated to http-interop/http-middleware 0.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "php": "^5.6 || ^7.0",
     "psr/http-message": "^1.0",
     "zendframework/zend-escaper": "^2.3",
-    "http-interop/http-middleware": "^0.2.0"
+    "http-interop/http-middleware": "^0.2.1"
   },
   "require-dev": {
     "zendframework/zend-diactoros": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "php": "^5.6 || ^7.0",
     "psr/http-message": "^1.0",
     "zendframework/zend-escaper": "^2.3",
-    "http-interop/http-middleware": "^0.2.1"
+    "http-interop/http-middleware": "^0.3.0"
   },
   "require-dev": {
     "zendframework/zend-diactoros": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2c7f26fd1c911205382aaf7bde89a73a",
-    "content-hash": "cbf247339c2c5e52306e4fa8f027ba09",
+    "hash": "d4360782cb06bbc2755e8125ae481637",
+    "content-hash": "445e9aeb845bf9c2ca2e5de752f17144",
     "packages": [
         {
             "name": "http-interop/http-middleware",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9"
+                "reference": "08c50a4c571b2ac6c8efcdb4371cb06e1c90820c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9",
-                "reference": "ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9",
+                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/08c50a4c571b2ac6c8efcdb4371cb06e1c90820c",
+                "reference": "08c50a4c571b2ac6c8efcdb4371cb06e1c90820c",
                 "shasum": ""
             },
             "require": {
@@ -57,7 +57,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-09-25 13:30:27"
+            "time": "2016-11-19 15:51:20"
         },
         {
             "name": "psr/http-message",

--- a/composer.lock
+++ b/composer.lock
@@ -4,12 +4,12 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d4360782cb06bbc2755e8125ae481637",
-    "content-hash": "445e9aeb845bf9c2ca2e5de752f17144",
+    "hash": "bcf7ce3c9938332204c2d37c136d5677",
+    "content-hash": "6bcdcd77c5107e4afc10ab8d0640f3be",
     "packages": [
         {
             "name": "http-interop/http-middleware",
-            "version": "0.2.1",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/http-interop/http-middleware.git",

--- a/doc/book/api.md
+++ b/doc/book/api.md
@@ -11,7 +11,6 @@ has been discussed previously. Its API is:
 namespace Zend\Stratigility;
 
 use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\MiddlewareInterface as InteropMiddlewareInterface;
 use Interop\Http\Middleware\ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -19,8 +18,8 @@ use Psr\Http\Message\ServerRequestInterface;
 class MiddlewarePipe implements MiddlewareInterface, ServerMiddlewareInterface
 {
     public function pipe(
-        string|callable|InteropMiddlewareInterface|ServerRequestInterface $path,
-        callable|InteropMiddlewareInterface|ServerRequestInterface $middleware = null
+        string|callable|ServerMiddlewareInterface|ServerRequestInterface $path,
+        callable|ServerMiddlewareInterface|ServerRequestInterface $middleware = null
     );
 
     public function __invoke(

--- a/doc/book/middleware.md
+++ b/doc/book/middleware.md
@@ -143,7 +143,7 @@ Within Stratigility, middleware can be:
   [PSR-7](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md)
   ServerRequest and Response (in that order), and, optionally, a callable (for
   invoking the next middleware in the queue, if any).
-- Any [http-interop 0.2.1 - middleware](https://github.com/http-interop/http-middleware/tree/0.2.1).
+- Any [http-interop 0.3.0 - middleware](https://github.com/http-interop/http-middleware/tree/0.3.0).
   `Zend\Stratigility\MiddlewarePipe` implements
   `Interop\Http\Middleware\ServerMiddlewareInterface`.
 - An object implementing `Zend\Stratigility\MiddlewareInterface`.

--- a/doc/book/middleware.md
+++ b/doc/book/middleware.md
@@ -143,7 +143,7 @@ Within Stratigility, middleware can be:
   [PSR-7](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md)
   ServerRequest and Response (in that order), and, optionally, a callable (for
   invoking the next middleware in the queue, if any).
-- Any [http-interop 0.2.0 - middleware](https://github.com/http-interop/http-middleware/tree/ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9).
+- Any [http-interop 0.2.1 - middleware](https://github.com/http-interop/http-middleware/tree/0.2.1).
   `Zend\Stratigility\MiddlewarePipe` implements
   `Interop\Http\Middleware\ServerMiddlewareInterface`.
 - An object implementing `Zend\Stratigility\MiddlewareInterface`.

--- a/doc/book/migration/to-v2.md
+++ b/doc/book/migration/to-v2.md
@@ -155,7 +155,7 @@ To summarize:
 ## http-interop compatibility
 
 Starting in version 1.3.2, we offer compatibility with
-[http-interop middleware 0.2.1](https://github.com/http-interop/http-middleware/tree/0.2.1).
+[http-interop middleware 0.3.0](https://github.com/http-interop/http-middleware/tree/0.3.0).
 That version of the specification defines the following interfaces:
 
 ```php

--- a/doc/book/migration/to-v2.md
+++ b/doc/book/migration/to-v2.md
@@ -154,8 +154,8 @@ To summarize:
 
 ## http-interop compatibility
 
-Starting in version 1.3.0, we offer compatibility with
-[http-interop middleware 0.2.0](https://github.com/http-interop/http-middleware/tree/ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9).
+Starting in version 1.3.2, we offer compatibility with
+[http-interop middleware 0.2.1](https://github.com/http-interop/http-middleware/tree/0.2.1).
 That version of the specification defines the following interfaces:
 
 ```php
@@ -168,11 +168,6 @@ use Psr\Http\Message\ServerRequestInterface;
 interface DelegateInterface
 {
     public function process(RequestInterface $request) : ResponseInterface;
-}
-
-interface MiddlewareInterface
-{
-    public function process(RequestInterface $request, DelegateInterface $delegate) : ResponseInterface;
 }
 
 interface ServerMiddlewareInterface

--- a/src/Route.php
+++ b/src/Route.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Stratigility;
 
-use Interop\Http\Middleware\MiddlewareInterface as InteropMiddlewareInterface;
 use Interop\Http\Middleware\ServerMiddlewareInterface;
 use InvalidArgumentException;
 use OutOfRangeException;
@@ -37,8 +36,8 @@ class Route
 
     /**
      * @param string $path
-     * @param callable|InteropMiddlewareInterface|ServerMiddlewareInterface $handler
-     * @throws Exception\InvalidArgumentException if the $handler provided is
+     * @param callable|ServerMiddlewareInterface $handler
+     * @throws Exception\InvalidMiddlewareException if the $handler provided is
      *     neither a callable nor an http-interop implementation.
      */
     public function __construct($path, $handler)
@@ -49,7 +48,6 @@ class Route
 
         if (! (is_callable($handler)
             || $handler instanceof ServerMiddlewareInterface
-            || $handler instanceof InteropMiddlewareInterface
         )) {
             throw new Exception\InvalidMiddlewareException(sprintf(
                 'Middleware must be callable or implement an http-interop middleware interface; received %s',


### PR DESCRIPTION
In 0.2.1 release MiddlewareInterface has been removed.

Not sure if it could be released in `1.3.2`.