### PR TITLE
doc-block typo

### DIFF
--- a/src/Delegate/CallableDelegateDecorator.php
+++ b/src/Delegate/CallableDelegateDecorator.php
@@ -18,7 +18,7 @@ use Psr\Http\Message\ResponseInterface;
 class CallableDelegateDecorator implements DelegateInterface
 {
     /**
-     * @var DelegateInterface
+     * @var callable
      */
     private $delegate;
 


### PR DESCRIPTION
Hello @weierophinney,
wouldn't it also make more sense to rename the `$delegate` property and parameter to `$next` given that the purpose of this decorator is to wrap a standard - stratigility < 1.3 - $next callable? I visually (and mentally) tend to associate the `$delegate` job with `$delegate->process($req)` calls and old `$next` callables job with `$next($req, $res)` calls. Of course it's a mere matter of names. In this case the decorator "decorates the callable" by "adding" its own process() method with a proxy invocation of $next.

kind regards