### PR TITLE
Ensure that MiddlewarePipes are called as callables if an error is present

### DIFF
--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -76,6 +76,11 @@ class Dispatch
             $this->setResponsePrototype($response);
         }
 
+        // Handle middleware pipes as callables if an $err is present
+        if ($route->handler instanceof MiddlewarePipe && null !== $err) {
+            return $this->dispatchCallableMiddleware($route->handler, $next, $request, $response, $err);
+        }
+
         if ($route->handler instanceof ServerMiddlewareInterface) {
             return $this->dispatchInteropMiddleware($route->handler, $next, $request);
         }

--- a/test/DispatchTest.php
+++ b/test/DispatchTest.php
@@ -441,9 +441,6 @@ class DispatchTest extends TestCase
         );
     }
 
-    /**
-     * @todo Remove this test for version 2.0
-     */
     public function testInvokingWithMiddlewarePipeAndErrorDispatchesNextErrorMiddleware()
     {
         $error    = new RuntimeException('expected');
@@ -486,9 +483,6 @@ class DispatchTest extends TestCase
         );
     }
 
-    /**
-     * @todo Remove this test for version 2.0
-     */
     public function testInvokingWithMiddlewarePipeAndNoErrorDispatchesAsInteropMiddleware()
     {
         $request  = $this->prophesize(ServerRequestInterface::class)->reveal();

--- a/test/DispatchTest.php
+++ b/test/DispatchTest.php
@@ -441,9 +441,20 @@ class DispatchTest extends TestCase
         );
     }
 
-    public function testInvokingWithMiddlewarePipeAndErrorDispatchesNextErrorMiddleware()
+    public function errorProvider()
     {
-        $error    = new RuntimeException('expected');
+        yield 'exception' => [new \Exception('expected')];
+        yield 'derivative-exception' => [new RuntimeException('expected')];
+        if (version_compare(\PHP_VERSION, '7.0', 'gte')) {
+            yield 'throwable' => [new \Error('expected')];
+        }
+    }
+
+    /**
+     * @dataProvider errorProvider
+     */
+    public function testInvokingWithMiddlewarePipeAndErrorDispatchesNextErrorMiddleware($error)
+    {
         $request  = $this->prophesize(ServerRequestInterface::class)->reveal();
         $response = $this->prophesize(ResponseInterface::class)->reveal();
         $expected = $this->prophesize(ResponseInterface::class)->reveal();


### PR DESCRIPTION
As reported in zendframework/zend-expressive#416, error middleware nested inside a `MiddlewarePipe` was not being dispatched. This was due to the fact that `Dispatch` was identifying the pipeline as http-interop middleware, and thus dropping the `$err` argument (as interop middleware cannot accept that argument).

Theis patch updates `Dispatch` to check if the middleware is a `MiddlewarePipe` and a non-null `$err` is present; if so, it now dispatches it as callable middleware instead of as interop middleware.