### PR TITLE
Update to http-middleware 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,24 +144,6 @@ details.
 
 - Nothing.
 
-## 1.4.0 - TBD
-
-### Added
-
-- Nothing.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- Nothing.
-
-### Fixed
-
-- Nothing.
-
 ## 1.3.3 - TBD
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php": "^5.6 || ^7.0",
     "psr/http-message": "^1.0",
     "zendframework/zend-escaper": "^2.3",
-    "http-interop/http-middleware": "^0.2.0"
+    "http-interop/http-middleware": "^0.4.1"
   },
   "require-dev": {
     "zendframework/zend-diactoros": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require-dev": {
     "zendframework/zend-diactoros": "^1.0",
-    "phpunit/phpunit": "^5.6",
+    "phpunit/phpunit": "^5.7",
     "zendframework/zend-coding-standard": "~1.0.0"
   },
   "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bd8ae55ecc56fbd48534a3ba472f0056",
-    "content-hash": "cbf247339c2c5e52306e4fa8f027ba09",
+    "hash": "09fdd5a1b548b58a2774f8c52cf8d8ae",
+    "content-hash": "9442cfcfcdbe6ae0bd41116e931bb940",
     "packages": [
         {
             "name": "http-interop/http-middleware",
-            "version": "0.2.0",
+            "version": "0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9"
+                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9",
-                "reference": "ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9",
+                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/9a801fe60e70d5d608b61d56b2dcde29516c81b9",
+                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9",
                 "shasum": ""
             },
             "require": {
@@ -33,7 +33,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Interop\\Http\\Middleware\\": "src/"
+                    "Interop\\Http\\ServerMiddleware\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -46,7 +46,7 @@
                     "homepage": "http://www.php-fig.org/"
                 }
             ],
-            "description": "Common interface for HTTP middleware",
+            "description": "Common interface for HTTP server-side middleware",
             "keywords": [
                 "factory",
                 "http",
@@ -57,7 +57,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-09-25 13:30:27"
+            "time": "2017-01-14 15:23:42"
         },
         {
             "name": "psr/http-message",
@@ -352,16 +352,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
                 "shasum": ""
             },
             "require": {
@@ -395,20 +395,20 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-11-25 06:54:22"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
                 "shasum": ""
             },
             "require": {
@@ -416,10 +416,11 @@
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
                 "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0"
+                "sebastian/recursion-context": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0"
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
@@ -457,20 +458,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-11-21 14:58:47"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.2",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6cba06ff75a1a63a71033e1a01b89056f3af1e8d"
+                "reference": "c19cfc7cbb0e9338d8c469c7eedecc2a428b0971"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6cba06ff75a1a63a71033e1a01b89056f3af1e8d",
-                "reference": "6cba06ff75a1a63a71033e1a01b89056f3af1e8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c19cfc7cbb0e9338d8c469c7eedecc2a428b0971",
+                "reference": "c19cfc7cbb0e9338d8c469c7eedecc2a428b0971",
                 "shasum": ""
             },
             "require": {
@@ -520,20 +521,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-11-01 05:06:24"
+            "time": "2017-01-20 15:06:43"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -567,7 +568,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -656,16 +657,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
                 "shasum": ""
             },
             "require": {
@@ -701,20 +702,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2016-11-15 14:06:22"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.6.2",
+            "version": "5.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "cd13b23ac5a519a4708e00736c26ee0bb28b2e01"
+                "reference": "caf8141b89691498d91aaac6c82e9cd5f685ae86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/cd13b23ac5a519a4708e00736c26ee0bb28b2e01",
-                "reference": "cd13b23ac5a519a4708e00736c26ee0bb28b2e01",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/caf8141b89691498d91aaac6c82e9cd5f685ae86",
+                "reference": "caf8141b89691498d91aaac6c82e9cd5f685ae86",
                 "shasum": ""
             },
             "require": {
@@ -725,18 +726,18 @@
                 "ext-xml": "*",
                 "myclabs/deep-copy": "~1.3",
                 "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^4.0.1",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.4",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "~1.1",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
-                "sebastian/environment": "^1.3 || ^2.0",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/object-enumerator": "~1.0",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.0 || ^2.0",
+                "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
                 "sebastian/version": "~1.0|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
@@ -757,7 +758,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.6.x-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -783,27 +784,27 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-10-25 07:40:25"
+            "time": "2017-01-22 08:39:59"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.0",
+            "version": "3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2"
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
-                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.6 || ^7.0",
                 "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2"
+                "sebastian/exporter": "^1.2 || ^2.0"
             },
             "conflict": {
                 "phpunit/phpunit": "<5.4.0"
@@ -842,7 +843,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-10-09 07:01:45"
+            "time": "2016-12-08 20:27:08"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -891,22 +892,22 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -951,7 +952,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2016-11-19 09:18:40"
         },
         {
             "name": "sebastian/diff",
@@ -1007,28 +1008,28 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1053,25 +1054,25 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-11-26 07:53:53"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -1080,7 +1081,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1120,7 +1121,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-11-19 08:54:04"
         },
         {
             "name": "sebastian/global-state",
@@ -1175,21 +1176,21 @@
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
+                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.6",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~5"
@@ -1197,7 +1198,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1217,20 +1218,20 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-01-28 13:25:10"
+            "time": "2016-11-19 07:35:10"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
@@ -1242,7 +1243,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1270,7 +1271,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-11-19 07:33:16"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1316,16 +1317,16 @@
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
                 "shasum": ""
             },
             "require": {
@@ -1355,20 +1356,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-02-04 12:56:52"
+            "time": "2016-10-03 07:35:21"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed"
+                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
-                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9b324f3a1132459a7274a0ace2e1b766ba80930f",
+                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f",
                 "shasum": ""
             },
             "require": {
@@ -1433,29 +1434,35 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-09-01 23:53:02"
+            "time": "2016-11-30 04:02:31"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.6",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27"
+                "reference": "50eadbd7926e31842893c957eca362b21592a97d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7ff51b06c6c3d5cc6686df69004a42c69df09e27",
-                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/50eadbd7926e31842893c957eca362b21592a97d",
+                "reference": "50eadbd7926e31842893c957eca362b21592a97d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1482,24 +1489,24 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-24 18:41:13"
+            "time": "2017-01-03 13:51:32"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -1508,7 +1515,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -1532,7 +1539,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2016-11-23 20:04:58"
         },
         {
             "name": "zendframework/zend-coding-standard",
@@ -1565,16 +1572,16 @@
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.3.7",
+            "version": "1.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "969ff423d3f201da3ff718a5831bb999bb0669b0"
+                "reference": "83e8d98b9915de76c659ce27d683c02a0f99fa90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/969ff423d3f201da3ff718a5831bb999bb0669b0",
-                "reference": "969ff423d3f201da3ff718a5831bb999bb0669b0",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/83e8d98b9915de76c659ce27d683c02a0f99fa90",
+                "reference": "83e8d98b9915de76c659ce27d683c02a0f99fa90",
                 "shasum": ""
             },
             "require": {
@@ -1586,7 +1593,7 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6 || ^5.5",
-                "squizlabs/php_codesniffer": "^2.3.1"
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
@@ -1611,7 +1618,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-10-11 13:25:21"
+            "time": "2017-01-23 04:53:24"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "09fdd5a1b548b58a2774f8c52cf8d8ae",
-    "content-hash": "9442cfcfcdbe6ae0bd41116e931bb940",
+    "hash": "6643772f3593fa6edf02a1d4013c6aae",
+    "content-hash": "7fd72b671fef81ffd9316c6cc18dcb48",
     "packages": [
         {
             "name": "http-interop/http-middleware",

--- a/doc/book/error-handlers.md
+++ b/doc/book/error-handlers.md
@@ -36,8 +36,8 @@ If you would like a templated response, you will need to write your own
 middleware; such middleware might look like the following:
 
 ```php
-use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\ServerMiddlewareInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 

--- a/doc/book/executing-middleware.md
+++ b/doc/book/executing-middleware.md
@@ -48,13 +48,9 @@ method to perform any additional logic you have, and then call on the parent in
 order to iterate through your stack of middleware:
 
 ```php
-use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\ServerMiddlewareInterface;
-use Psr\Http\Message\ServerRequestInterface as Request;
-
 class CustomMiddleware extends MiddlewarePipe
 {
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
         // perform some work...
 

--- a/doc/book/install.md
+++ b/doc/book/install.md
@@ -14,7 +14,9 @@ Stratigility has the following dependencies (which are managed by Composer):
   [Diactoros](https://zendframework.github.io/zend-diactoros/).
 
 - [`http-interop/http-middleware`](https://github.com/http-interop/http-middleware),
-  which provides the interfaces that will become PSR-15.
+  which provides the interfaces that will become PSR-15. In Stratigility 1.3,
+  this is pinned to the 0.2 series; in Stratigility 2.0, this is pinned to
+  0.4.1+.
 
 - `zendframework/zend-escaper`, used by the `ErrorHandler` middleware and the
   (legacy) `FinalHandler` implementation for escaping error messages prior to

--- a/doc/book/middleware.md
+++ b/doc/book/middleware.md
@@ -84,7 +84,7 @@ response object, and do something with it_.
 > }
 > ```
 >
-> Starting in http-interop/http-middleware, these becomes:
+> Starting in http-interop/http-middleware 0.4.1, these become:
 >
 > ```php
 > namespace Interop\Http\ServerMiddleware;

--- a/doc/book/middleware.md
+++ b/doc/book/middleware.md
@@ -51,7 +51,7 @@ response object, and do something with it_.
 > such as Slim, Relay, Adroit, etc.
 >
 > http-interop is a project attempting to standardize middleware signatures.
-> The signature it uses for server-side middleware is:
+> The signature until the 0.4.0 series for server-side middleware is:
 >
 > ```php
 > namespace Interop\Http\Middleware;
@@ -84,9 +84,37 @@ response object, and do something with it_.
 > }
 > ```
 >
-> Stratigility allows you to implement `ServerMiddlewareInterface` to provide
-> middleware.  Additionally, you can define `callable` middleware with the
-> following signature, and it will be dispatched as http-interop middleware:
+> Starting in http-interop/http-middleware, these becomes:
+>
+> ```php
+> namespace Interop\Http\ServerMiddleware;
+>
+> use Psr\Http\Message\ResponseInterface;
+> use Psr\Http\Message\ServerRequestInterface;
+>
+> interface MiddlewareInterface
+> {
+>     public function process(
+>         ServerRequestInterface $request,
+>         DelegateInterface $delegate
+>     ) : ResponseInterface;
+> }
+>
+> interface DelegateInterface
+> {
+>     public function process(
+>         ServerRequestInterface $request
+>     ) : ResponseInterface;
+> }
+> ```
+>
+> (Note the namespace change, the change in the middleware interface name, and
+> the change in the `DelegateInterface` signature.)
+>
+> Stratigility allows you to implement the http-interop/http-middleware
+> middleware interface to provide middleware.  Additionally, you can define
+> `callable` middleware with the following signature, and it will be dispatched
+> as http-interop middleware:
 >
 > ```php
 > function(
@@ -101,9 +129,6 @@ response object, and do something with it_.
 > As such, the above example can also be written as follows:
 >
 > ```php
-> use Interop\Http\Middleware\DelegateInterface;
-> use Zend\Diactoros\Response\TextResponse;
->
 > $app->pipe('/', function ($request, DelegateInterface $delegate) {
 >     if (! in_array($req->getUri()->getPath(), ['/', ''], true)) {
 >         return $delegate->process($req);
@@ -143,9 +168,12 @@ Within Stratigility, middleware can be:
   [PSR-7](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md)
   ServerRequest and Response (in that order), and, optionally, a callable (for
   invoking the next middleware in the queue, if any).
-- Any [http-interop 0.2.0 - middleware](https://github.com/http-interop/http-middleware/tree/ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9).
+- Any [http-interop 0.2.0 - middleware](https://github.com/http-interop/http-middleware/tree/0.2.0).
   `Zend\Stratigility\MiddlewarePipe` implements
-  `Interop\Http\Middleware\ServerMiddlewareInterface`.
+  `Interop\Http\Middleware\ServerMiddlewareInterface`. (Stratigility 1.3.0 series.)
+- Any [http-interop 0.4.1 - middleware](https://github.com/http-interop/http-middleware/tree/0.4.1).
+  `Zend\Stratigility\MiddlewarePipe` implements
+  `Interop\Http\Middleware\ServerMiddlewareInterface`. (Stratigility 2.0 series.)
 - An object implementing `Zend\Stratigility\MiddlewareInterface`.
   `Zend\Stratigility\MiddlewarePipe` implements this interface.
   (Legacy; this interface is deprecated starting in 1.3.0.)

--- a/doc/book/migration/to-v2.md
+++ b/doc/book/migration/to-v2.md
@@ -157,7 +157,7 @@ To summarize:
 ### http-middleware 0.2.0 and Stratigility 1.3
 
 Starting in version 1.3.0, we offer compatibility with
-[http-interop middleware 0.2.0](https://github.com/http-interop/http-middleware/tree/ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9).
+[http-interop/http-middleware 0.2.0](https://github.com/http-interop/http-middleware/tree/ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9).
 That version of the specification defines the following interfaces:
 
 ```php
@@ -202,11 +202,11 @@ prototype will be passed to the callable for the response argument.
 
 ### http-middleware 0.4.1 and Stratigility 2.0
 
-http-middleware 0.4.1 introduces breaking changes in the interfaces, including
-the following:
+http-interop/http-middleware 0.4.1 introduces breaking changes in the
+interfaces, including the following:
 
 - The namespace changes from `Interop\Http\Middleware` to
-  `Iterop\Http\ServerMiddleware`, signaling a change indicating that the project
+  `Interop\Http\ServerMiddleware`, signaling a change indicating that the project
   now only targests server-side middleware.
 
 - The interface `ServerMiddlewareInterface` is now more simply
@@ -223,12 +223,13 @@ accommodate, and could have been imported in parallel to the 0.2.0 interfaces.
 However, the second represents a signature change, which has necessitated a
 major version bump in Stratigility in order to remain compatible.
 
-Stratigility 2.0.0 therefor targets http-middleware 0.4.1, and that version
-(and compatible versions) only.
+Stratigility 2.0.0 therefor targets http-interop/http-middleware 0.4.1, and that
+version (and compatible versions) only.
 
 Additionally, starting in version 2.0.0, `MiddlewarePipe` *will no longer implement
-`Zend\Stratigility\MiddlewareInterface`, and only implement the http-interop
-`MiddlewareInterface`*. This has several repercussions.
+`Zend\Stratigility\MiddlewareInterface`, and only implement the
+http-interop/http-middleware `MiddlewareInterface`*. This has several
+repercussions.
 
 ### Callable middleware in version 1.3.0
 
@@ -238,7 +239,7 @@ recommend updating your code to prepare for version 2.0.0.
 First, **we recommend *never* using the `$response` argument provided to
 middleware.**
 
-The reason for this recommendation is two-fold. First, the http-interop
+The reason for this recommendation is two-fold. First, the http-interop/http-middleware
 interfaces do not provide it, and, as such, using it within your middleware
 makes your middleware incompatible. Second, and more importantly, is due to the
 reason why http-interop does not include the argument: usage can lead to
@@ -285,12 +286,12 @@ results.
 Second, either wrap your middleware in `CallableMiddlewareWrapper`, or ensure
 your pipeline composes a *response prototype* (doing so will implicitly
 decorate callable middleware). Either of these will ensure your middleware will
-work with http-interop delegators.
+work with http-interop/http-middleware delegators.
 
 ```php
 use Zend\Stratigility\Middleware\CallableMiddlewareWrapper;
 
-// Manually decorating callable middleware for use with http-interop:
+// Manually decorating callable middleware for use with http-middleware:
 $pipeline->pipe(new CallableMiddlewareWrapper($middleware, $response));
 
 // Auto-decorate middleware by providing a response prototype:
@@ -301,7 +302,7 @@ $pipeline->pipe($middleware);
 > ### CallableMiddlewareWrapper and Stratigility 2.0
 >
 > As noted above, version 2 of Stratigility is incompatible with version 1.3 due
-> to signature changes in the http-interop project. However, if you wrap your
+> to signature changes in the http-middleware project. However, if you wrap your
 > callable middleware using `CallableMiddlewareWrapper`, you will need to make
 > no changes in your application to make it forwards compatible.
 >
@@ -351,7 +352,7 @@ which simply proxies to the middleware when processed.
 > rewrite your middleware to implement the http-middleware 0.4.1 interfaces.
 
 Finally, if you are so inclined, you can rewrite your middleware to
-specifically implement one or the other of the http-interop middleware
+specifically implement one or the other of the http-interop/http-middleware
 interfaces. This is particularly relevant for class-based middleware, but can
 also be accomplished by using PHP 7 anonymous classes.
 
@@ -420,10 +421,11 @@ $pipeline->pipe(new class implements ServerMiddlewareInterface {
 > Using anonymous classes is likely overkill, as both v1.3.0 and v2.0.0 support
 > piping closures.
 
-If you want your middleware to work with either http-interop or with the
-pre-1.3.0 middleware signature, you can do that as well. To accomplish this, we
-provide `Zend\Stratigility\Delegate\CallableDelegateDecorator`, which will wrap
-a `callable $next` such that it may be used as a `DelegateInterface` implementation:
+If you want your middleware to work with either http-interop/http-middleware or
+with the pre-1.3.0 middleware signature, you can do that as well. To accomplish
+this, we provide `Zend\Stratigility\Delegate\CallableDelegateDecorator`, which
+will wrap a `callable $next` such that it may be used as a `DelegateInterface`
+implementation:
 
 ```php
 use Interop\Http\Middleware\DelegateInterface;
@@ -476,23 +478,27 @@ To summarize:
 
 - Never work with the provided `$response` argument, but instead manipulate the
   response returned from calling `$next`.
-- Ensure your pipeline can decorate callable middleware as http-interop
-  middleware. Do this by injecting a response prototype in the pipeline prior
-  to piping any middleware. (*Note: this is not necessary if all callable
-  middleware defines exactly two parameters, with the second type-hinting on
-  the http-interop `DelegateInterface`*.)
+
+- Ensure your pipeline can decorate callable middleware as http-interop/http-middleware.
+  Do this by injecting a response prototype in the pipeline prior to piping any
+  middleware. (*Note: this is not necessary if all callable middleware defines
+  exactly two parameters, with the second type-hinting on the http-interop
+  `DelegateInterface`*.)
+
 - Consider adapting your callable middleware to follow the http-interop middleware
   signature (`function (ServerRequestInterface $request, DelegateInterface $delegate)`);
   this will make it forward-compatible. (Be aware that this may require changes
   in import statements between Stratigility 1.3 and 2.0.)
-- Consider updating your class-based middleware to implement one of the
-  http-interop middleware interfaces, potentially keeping the `__invoke()` method
-  for interoperability with existing callable-based middleware runners. (Be
-  aware that this may require changes in import statements between Stratigility
+
+- Consider updating your class-based middleware to implement the
+  http-interop/http-middleware server middleware interface, potentially keeping
+  the `__invoke()` method for interoperability with existing callable-based
+  middleware runners. (Be aware that this may require changes in import
+  statements between Stratigility
   1.3 and 2.0.)
 
 The first and last suggestions in this list are strongly recommended to ensure
-forwards compatibility with http-interop, and to ensure your middleware works
+forwards compatibility with http-middleware, and to ensure your middleware works
 properly across middleware stacks.
 
 ### Callable middleware in version 2.0.0
@@ -524,7 +530,7 @@ pipeline, you must do one of the following:
     ```php
     $pipeline->pipe(new CallableMiddlewareWrapper($middleware, $response));
     // or CallableInteropMiddlewareWrapper, if your middleware implements
-    // the http-interop signature already.
+    // the http-middleware signature already.
     ```
 
 ### Invoking MiddlewarePipe instances in version 2.0.0
@@ -603,7 +609,7 @@ The following classes, methods, and arguments are removed starting in version
 - `Zend\Stratigility\ErrorMiddlewareInterface` (class)
 - `Zend\Stratigility\FinalHandler` (class)
 - `Zend\Stratigility\MiddlewareInterface`. Define your middleware as callables,
-  or using http-interop middleware interfaces instead.
+  or using http-interop/http-middleware interfaces instead.
 - `Zend\Stratigility\Utils::getArity()` (static method); no longer used
   internally.
 - The `$err` argument to `Zend\Stratigility\Next`'s `__invoke()` method. If
@@ -615,4 +621,4 @@ The following classes, methods, and arguments are removed starting in version
   [section on callable middleware](callable-middleware-in-version-1.3.0)
   for details, and adapt your middleware to no longer use the argument.
   While the legacy callable signature will continue to work, we recommend
-  implementing an http-interop middleware interface.
+  implementing an http-interop/http-middleware interface.

--- a/doc/book/migration/to-v2.md
+++ b/doc/book/migration/to-v2.md
@@ -207,7 +207,7 @@ interfaces, including the following:
 
 - The namespace changes from `Interop\Http\Middleware` to
   `Interop\Http\ServerMiddleware`, signaling a change indicating that the project
-  now only targests server-side middleware.
+  now only targets server-side middleware.
 
 - The interface `ServerMiddlewareInterface` is now more simply
   `MiddlewareInterface`, as the namespace indicates its usage in server-side

--- a/doc/book/migration/to-v2.md
+++ b/doc/book/migration/to-v2.md
@@ -1,6 +1,6 @@
 # Migrating to version 2
 
-Version 2 of Stratigility will be making several breaking changes to the API in
+Version 2 of Stratigility makes several breaking changes to the API in
 order to provide more flexibility, promote interoperability, and reduce
 complexity.
 
@@ -154,6 +154,8 @@ To summarize:
 
 ## http-interop compatibility
 
+### http-middleware 0.2.0 and Stratigility 1.3
+
 Starting in version 1.3.0, we offer compatibility with
 [http-interop middleware 0.2.0](https://github.com/http-interop/http-middleware/tree/ff545c87e97bf4d88f0cb7eb3e89f99aaa53d7a9).
 That version of the specification defines the following interfaces:
@@ -198,9 +200,35 @@ middleware piped to the pipeline will be wrapped in a
 converts it into an http-interop middleware type; when processed, the response
 prototype will be passed to the callable for the response argument.
 
-Starting in version 2.0.0, `MiddlewarePipe` *will no longer implement
+### http-middleware 0.4.1 and Stratigility 2.0
+
+http-middleware 0.4.1 introduces breaking changes in the interfaces, including
+the following:
+
+- The namespace changes from `Interop\Http\Middleware` to
+  `Iterop\Http\ServerMiddleware`, signaling a change indicating that the project
+  now only targests server-side middleware.
+
+- The interface `ServerMiddlewareInterface` is now more simply
+  `MiddlewareInterface`, as the namespace indicates its usage in server-side
+  applications. `Interop\Http\Middleware\MiddlewareInterface`, which targeted
+  client-side middleware, was removed entirely.
+
+- The method `DelegateInterface::process` now accepts specifically a
+  `Psr\Http\Message\ServerRequestInterface`, and not the more general
+  `RequestInterface`.
+
+The first two changes required only a change in import statements to
+accommodate, and could have been imported in parallel to the 0.2.0 interfaces.
+However, the second represents a signature change, which has necessitated a
+major version bump in Stratigility in order to remain compatible.
+
+Stratigility 2.0.0 therefor targets http-middleware 0.4.1, and that version
+(and compatible versions) only.
+
+Additionally, starting in version 2.0.0, `MiddlewarePipe` *will no longer implement
 `Zend\Stratigility\MiddlewareInterface`, and only implement the http-interop
-`ServerMiddlewareInterface`*. This has several repercussions.
+`MiddlewareInterface`*. This has several repercussions.
 
 ### Callable middleware in version 1.3.0
 
@@ -270,6 +298,16 @@ $pipeline->setResponsePrototype($response);
 $pipeline->pipe($middleware);
 ```
 
+> ### CallableMiddlewareWrapper and Stratigility 2.0
+>
+> As noted above, version 2 of Stratigility is incompatible with version 1.3 due
+> to signature changes in the http-interop project. However, if you wrap your
+> callable middleware using `CallableMiddlewareWrapper`, you will need to make
+> no changes in your application to make it forwards compatible.
+>
+> We recommend using this strategy if you need to do a stepped transition to
+> Stratigility 2.0.
+
 Third, and optionally, you can make one or both of the following changes to
 your callable middleware:
 
@@ -303,6 +341,15 @@ When you pipe such callable middleware to `MiddlewarePipeline`, it will be
 wrapped in a `Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper`,
 which simply proxies to the middleware when processed.
 
+> ### DelegateInterface and Stratigility 2.0
+>
+> Since the namespace within http-interop/http-middleware changes between
+> version 0.2.0 and 0.4.1, the above strategy will require making changes
+> multiple times: once when upgrading to Stratigility 1.3, and another when
+> upgrading to 2.0. As such, we recommend instead decorating your callable
+> middleware using the `CallableMiddlewareWrapper`, until such time as you can
+> rewrite your middleware to implement the http-middleware 0.4.1 interfaces.
+
 Finally, if you are so inclined, you can rewrite your middleware to
 specifically implement one or the other of the http-interop middleware
 interfaces. This is particularly relevant for class-based middleware, but can
@@ -330,9 +377,9 @@ class PingMiddleware
 This could be rewritten as follows:
 
 ```php
+use Interop\Http\Middleware\DelegateInterface;
+use Interop\Http\Middleware\ServerMiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Middleware\DelegateInterface;
-use Psr\Http\Middleware\ServerMiddlewareInterface;
 use Zend\Diactoros\Response\JsonResponse;
 
 class PingMiddleware implements ServerMiddlewareInterface
@@ -357,9 +404,9 @@ $pipeline->pipe(function ($request, $response, $next) {
 we could wrap this in an anonymous class instead:
 
 ```php
+use Interop\Http\Middleware\DelegateInterface;
+use Interop\Http\Middleware\ServerMiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Middleware\DelegateInterface;
-use Psr\Http\Middleware\ServerMiddlewareInterface;
 use Zend\Diactoros\Response\JsonResponse;
 
 $pipeline->pipe(new class implements ServerMiddlewareInterface {
@@ -379,10 +426,10 @@ provide `Zend\Stratigility\Delegate\CallableDelegateDecorator`, which will wrap
 a `callable $next` such that it may be used as a `DelegateInterface` implementation:
 
 ```php
+use Interop\Http\Middleware\DelegateInterface;
+use Interop\Http\Middleware\ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Middleware\DelegateInterface;
-use Psr\Http\Middleware\ServerMiddlewareInterface;
 use Zend\Diactoros\Response\JsonResponse;
 use Zend\Stratigility\Delegate\CallableDelegateDecorator;
 
@@ -403,6 +450,28 @@ class PingMiddleware implements ServerMiddlewareInterface
 }
 ```
 
+> ### Implementing http-interop between Stratigility 1.3 and 2.0
+>
+> While you _can_ write your middleware to implement the
+> http-interop/http-middleware middleware interface, please be aware that if you
+> do so, you will need to take additional steps when upgrading from 1.3 to 2.0.
+> 
+> In most cases, you should be able to simply change the import statements
+> within your class file. As an example, if you have the following in your
+> Stratigility 1.3-based project:
+> 
+> ```php
+> use Interop\Http\Middleware\DelegateInterface;
+> use Interop\Http\Middleware\ServerMiddlewareInterface;
+> ```
+>
+> The imports would become:
+>
+> ```php
+> use Interop\Http\ServerMiddleware\DelegateInterface;
+> use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
+> ```
+
 To summarize:
 
 - Never work with the provided `$response` argument, but instead manipulate the
@@ -414,10 +483,13 @@ To summarize:
   the http-interop `DelegateInterface`*.)
 - Consider adapting your callable middleware to follow the http-interop middleware
   signature (`function (ServerRequestInterface $request, DelegateInterface $delegate)`);
-  this will make it forward-compatible.
+  this will make it forward-compatible. (Be aware that this may require changes
+  in import statements between Stratigility 1.3 and 2.0.)
 - Consider updating your class-based middleware to implement one of the
   http-interop middleware interfaces, potentially keeping the `__invoke()` method
-  for interoperability with existing callable-based middleware runners.
+  for interoperability with existing callable-based middleware runners. (Be
+  aware that this may require changes in import statements between Stratigility
+  1.3 and 2.0.)
 
 The first and last suggestions in this list are strongly recommended to ensure
 forwards compatibility with http-interop, and to ensure your middleware works
@@ -517,7 +589,7 @@ The following signature changes were made with the 2.0.0 release:
 
 - `Zend\Stratigility\Next`:
   - The `$done` constructor argument was renamed to `$nextDelegate`, and now
-    allows either `callable` or `Interop\Http\Middleware\DelegateInterface`
+    allows either `callable` or `Interop\Http\ServerMiddleware\DelegateInterface`
     arguments.
   - The `$response` argument to `__invoke()` was removed.
   - The (optional) `$err` argument to `__invoke()` was removed.

--- a/src/Delegate/CallableDelegateDecorator.php
+++ b/src/Delegate/CallableDelegateDecorator.php
@@ -7,9 +7,9 @@
 
 namespace Zend\Stratigility\Delegate;
 
-use Interop\Http\Middleware\DelegateInterface;
-use Psr\Http\Message\RequestInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Decorate callable delegates as http-interop delegates in order to process
@@ -42,7 +42,7 @@ class CallableDelegateDecorator implements DelegateInterface
      *
      * {@inheritDoc}
      */
-    public function process(RequestInterface $request)
+    public function process(ServerRequestInterface $request)
     {
         $delegate = $this->delegate;
         return $delegate($request, $this->response);

--- a/src/Delegate/CallableDelegateDecorator.php
+++ b/src/Delegate/CallableDelegateDecorator.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/src/Middleware/CallableInteropMiddlewareWrapper.php
+++ b/src/Middleware/CallableInteropMiddlewareWrapper.php
@@ -7,11 +7,11 @@
 
 namespace Zend\Stratigility\Middleware;
 
-use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\ServerMiddlewareInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as InteropMiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-class CallableInteropMiddlewareWrapper implements ServerMiddlewareInterface
+class CallableInteropMiddlewareWrapper implements InteropMiddlewareInterface
 {
     /**
      * @param callable

--- a/src/Middleware/CallableInteropMiddlewareWrapper.php
+++ b/src/Middleware/CallableInteropMiddlewareWrapper.php
@@ -8,10 +8,10 @@
 namespace Zend\Stratigility\Middleware;
 
 use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as InteropMiddlewareInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-class CallableInteropMiddlewareWrapper implements InteropMiddlewareInterface
+class CallableInteropMiddlewareWrapper implements ServerMiddlewareInterface
 {
     /**
      * @param callable

--- a/src/Middleware/CallableInteropMiddlewareWrapper.php
+++ b/src/Middleware/CallableInteropMiddlewareWrapper.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/src/Middleware/CallableMiddlewareWrapper.php
+++ b/src/Middleware/CallableMiddlewareWrapper.php
@@ -8,7 +8,7 @@
 namespace Zend\Stratigility\Middleware;
 
 use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as InteropMiddlewareInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Stratigility\Next;
@@ -17,7 +17,7 @@ use Zend\Stratigility\Next;
  * Decorate legacy callable middleware to make it dispatchable as server
  * middleware.
  */
-class CallableMiddlewareWrapper implements InteropMiddlewareInterface
+class CallableMiddlewareWrapper implements ServerMiddlewareInterface
 {
     /**
      * @var callable

--- a/src/Middleware/CallableMiddlewareWrapper.php
+++ b/src/Middleware/CallableMiddlewareWrapper.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/src/Middleware/CallableMiddlewareWrapper.php
+++ b/src/Middleware/CallableMiddlewareWrapper.php
@@ -7,8 +7,8 @@
 
 namespace Zend\Stratigility\Middleware;
 
-use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\ServerMiddlewareInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as InteropMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Stratigility\Next;
@@ -17,7 +17,7 @@ use Zend\Stratigility\Next;
  * Decorate legacy callable middleware to make it dispatchable as server
  * middleware.
  */
-class CallableMiddlewareWrapper implements ServerMiddlewareInterface
+class CallableMiddlewareWrapper implements InteropMiddlewareInterface
 {
     /**
      * @var callable

--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -9,8 +9,8 @@ namespace Zend\Stratigility\Middleware;
 
 use ErrorException;
 use Exception;
-use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\ServerMiddlewareInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;

--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -7,8 +7,8 @@
 
 namespace Zend\Stratigility\Middleware;
 
-use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\ServerMiddlewareInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Stratigility\Delegate\CallableDelegateDecorator;

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -8,8 +8,8 @@
 namespace Zend\Stratigility;
 
 use Closure;
-use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\ServerMiddlewareInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use ReflectionFunction;
@@ -275,8 +275,7 @@ class MiddlewarePipe implements ServerMiddlewareInterface
     private function isInteropMiddleware($middleware)
     {
         return ! is_callable($middleware)
-            && ($middleware instanceof ServerMiddlewareInterface
-                || $middleware instanceof InteropMiddlewareInterface);
+            && $middleware instanceof ServerMiddlewareInterface;
     }
 
     /**

--- a/src/Next.php
+++ b/src/Next.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/src/Next.php
+++ b/src/Next.php
@@ -7,7 +7,7 @@
 
 namespace Zend\Stratigility;
 
-use Interop\Http\Middleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
 use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -80,14 +80,14 @@ class Next implements DelegateInterface
     }
 
     /**
-     * @param RequestInterface $request
+     * @param ServerRequestInterface $request
      * @return ResponseInterface
      * @throws Exception\MissingResponseException If the queue is exhausted, and
      *     no "next delegate" is present.
      * @throws Exception\MissingResponseException If the middleware executed does
      *     not return a response.
      */
-    public function process(RequestInterface $request)
+    public function process(ServerRequestInterface $request)
     {
         $request  = $this->resetPath($request);
 
@@ -152,10 +152,10 @@ class Next implements DelegateInterface
     /**
      * Reset the path, if a segment was previously stripped
      *
-     * @param RequestInterface $request
-     * @return RequestInterface
+     * @param ServerRequestInterface $request
+     * @return ServerRequestInterface
      */
-    private function resetPath(RequestInterface $request)
+    private function resetPath(ServerRequestInterface $request)
     {
         if (! $this->removed) {
             return $request;
@@ -205,11 +205,11 @@ class Next implements DelegateInterface
     /**
      * Strip the route from the request path
      *
-     * @param RequestInterface $request
+     * @param ServerRequestInterface $request
      * @param string $route
-     * @return RequestInterface
+     * @return ServerRequestInterface
      */
-    private function stripRouteFromPath(RequestInterface $request, $route)
+    private function stripRouteFromPath(ServerRequestInterface $request, $route)
     {
         $this->removed = $route;
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -7,8 +7,7 @@
 
 namespace Zend\Stratigility;
 
-use Interop\Http\Middleware\MiddlewareInterface as InteropMiddlewareInterface;
-use Interop\Http\Middleware\ServerMiddlewareInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use InvalidArgumentException;
 use OutOfRangeException;
 
@@ -24,7 +23,7 @@ use OutOfRangeException;
 class Route
 {
     /**
-     * @var InteropMiddlewareInterface|ServerMiddlewareInterface
+     * @var ServerMiddlewareInterface
      */
     protected $handler;
 
@@ -35,9 +34,9 @@ class Route
 
     /**
      * @param string $path
-     * @param InteropMiddlewareInterface|ServerMiddlewareInterface $handler
+     * @param ServerMiddlewareInterface $handler
      * @throws Exception\InvalidMiddlewareException if the $handler provided is
-     *     not an http-interop middleare type.
+     *     not an http-interop middleware type.
      */
     public function __construct($path, $handler)
     {
@@ -45,10 +44,7 @@ class Route
             throw new InvalidArgumentException('Path must be a string');
         }
 
-        if (! ($handler instanceof ServerMiddlewareInterface
-                || $handler instanceof InteropMiddlewareInterface
-            )
-        ) {
+        if (! $handler instanceof ServerMiddlewareInterface) {
             throw new Exception\InvalidMiddlewareException(sprintf(
                 'Middleware must implement an http-interop middleware interface; received %s',
                 is_object($handler) ? get_class($handler) : gettype($handler)

--- a/src/Route.php
+++ b/src/Route.php
@@ -35,20 +35,11 @@ class Route
     /**
      * @param string $path
      * @param ServerMiddlewareInterface $handler
-     * @throws Exception\InvalidMiddlewareException if the $handler provided is
-     *     not an http-interop middleware type.
      */
-    public function __construct($path, $handler)
+    public function __construct($path, ServerMiddlewareInterface $handler)
     {
         if (! is_string($path)) {
             throw new InvalidArgumentException('Path must be a string');
-        }
-
-        if (! $handler instanceof ServerMiddlewareInterface) {
-            throw new Exception\InvalidMiddlewareException(sprintf(
-                'Middleware must implement an http-interop middleware interface; received %s',
-                is_object($handler) ? get_class($handler) : gettype($handler)
-            ));
         }
 
         $this->path    = $path;

--- a/test/Middleware/CallableInteropMiddlewareWrapperTest.php
+++ b/test/Middleware/CallableInteropMiddlewareWrapperTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/test/Middleware/CallableInteropMiddlewareWrapperTest.php
+++ b/test/Middleware/CallableInteropMiddlewareWrapperTest.php
@@ -7,8 +7,8 @@
 
 namespace ZendTest\Stratigility\Middleware;
 
-use Interop\Http\Middleware\DelegateInterface;
-use PHPUnit\Framework\TestCase;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use PHPUnit_Framework_TestCase as TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper;

--- a/test/Middleware/CallableInteropMiddlewareWrapperTest.php
+++ b/test/Middleware/CallableInteropMiddlewareWrapperTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\Stratigility\Middleware;
 
 use Interop\Http\ServerMiddleware\DelegateInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper;

--- a/test/Middleware/CallableMiddlewareWrapperTest.php
+++ b/test/Middleware/CallableMiddlewareWrapperTest.php
@@ -8,8 +8,8 @@
 namespace ZendTest\Stratigility\Middleware;
 
 use Closure;
-use Interop\Http\Middleware\DelegateInterface;
-use PHPUnit\Framework\TestCase;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use PHPUnit_Framework_TestCase as TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Stratigility\Middleware\CallableMiddlewareWrapper;

--- a/test/Middleware/CallableMiddlewareWrapperTest.php
+++ b/test/Middleware/CallableMiddlewareWrapperTest.php
@@ -9,7 +9,7 @@ namespace ZendTest\Stratigility\Middleware;
 
 use Closure;
 use Interop\Http\ServerMiddleware\DelegateInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Stratigility\Middleware\CallableMiddlewareWrapper;

--- a/test/Middleware/CallableMiddlewareWrapperTest.php
+++ b/test/Middleware/CallableMiddlewareWrapperTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/test/Middleware/ErrorHandlerTest.php
+++ b/test/Middleware/ErrorHandlerTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\Stratigility\Middleware;
 
 use Interop\Http\ServerMiddleware\DelegateInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/test/Middleware/ErrorHandlerTest.php
+++ b/test/Middleware/ErrorHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/test/Middleware/ErrorHandlerTest.php
+++ b/test/Middleware/ErrorHandlerTest.php
@@ -7,8 +7,8 @@
 
 namespace ZendTest\Stratigility\Middleware;
 
-use Interop\Http\Middleware\DelegateInterface;
-use PHPUnit\Framework\TestCase;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/test/Middleware/NotFoundHandlerTest.php
+++ b/test/Middleware/NotFoundHandlerTest.php
@@ -7,8 +7,8 @@
 
 namespace ZendTest\Stratigility\Middleware;
 
-use Interop\Http\Middleware\DelegateInterface;
-use PHPUnit\Framework\TestCase;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use PHPUnit_Framework_TestCase as TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;

--- a/test/Middleware/NotFoundHandlerTest.php
+++ b/test/Middleware/NotFoundHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/test/Middleware/NotFoundHandlerTest.php
+++ b/test/Middleware/NotFoundHandlerTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\Stratigility\Middleware;
 
 use Interop\Http\ServerMiddleware\DelegateInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -7,9 +7,9 @@
 
 namespace ZendTest\Stratigility;
 
-use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\ServerMiddlewareInterface;
-use PHPUnit\Framework\TestCase;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
+use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -9,7 +9,7 @@ namespace ZendTest\Stratigility;
 
 use Interop\Http\ServerMiddleware\DelegateInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -7,8 +7,8 @@
 
 namespace ZendTest\Stratigility;
 
-use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\ServerMiddlewareInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use PHPUnit_Framework_Assert as Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -9,7 +9,7 @@ namespace ZendTest\Stratigility;
 
 use Interop\Http\ServerMiddleware\DelegateInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
-use PHPUnit_Framework_Assert as Assert;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://framework.zend.com/license New BSD License
  */
 

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\Stratigility;
 
-use Interop\Http\Middleware\ServerMiddlewareInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use InvalidArgumentException;
 use OutOfRangeException;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
http-interop/http-middleware 0.4.1 is the latest revision, and likely the version that will be used during the FIG review period. It makes the following changes:

- The namespace changes from `Interop\Http\Middleware` to `Interop\Http\ServerMiddleware`, to indicate that the specification is only dealing with server-side middleware.
- The interface `ServerMiddlewareInterface` is renamed to `MiddlewareInterface`, as the namespace change makes it clear what type of middleware is being defined.
- The signature of `DelegateInterface::process` now accepts specifically a `ServerRequestInterface` instead of a more general `RequestInterface`.

Updating to these changes means the following breaking changes:

- We no longer support the interfaces as defined in 0.2.0.
- `Next::process()` now typehints against `ServerRequestInterface`.

The above result in a few breaking changes in the develop branch:

- `Zend\Stratigility\Next` and `Zend\Stratigility\Delegate\CallableDelegateDecorator::process` have changed signatures, due to the changes to `DelegateInterface::process`; if developers were extending these previously, their code now breaks.
- Stratigility no longer accepts middleware implementing the http-middleware 0.2.0 signatures, as those were under different namespaces and/or names.

~~I'm currently targeting this at a 1.4.0 release; however, due to the breaking changes, I could target it at a 2.0.0 release. If consensus is to take this latter route, I'll update this repository to merge in the changes currently in the develop branch as well.~~

This targets develop, which is the 2.0.0 feature branch at this time.