### PR TITLE
Pipe should not decorate MiddlewarePipe instances

### DIFF
--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -128,10 +128,9 @@ class MiddlewarePipe implements ServerMiddlewareInterface
             $path       = '/';
         }
 
-        // Decorate callable middleware as http-interop middleware if we have
-        // a response prototype present.
+        // Decorate callable middleware as http-interop middleware
         if (is_callable($middleware)
-            && ! $this->isInteropMiddleware($middleware)
+            && ! $middleware instanceof ServerMiddlewareInterface
         ) {
             $middleware = $this->decorateCallableMiddleware($middleware);
         }
@@ -264,18 +263,6 @@ class MiddlewarePipe implements ServerMiddlewareInterface
         );
 
         return $this->callableMiddlewareDecorator;
-    }
-
-    /**
-     * Is the provided middleware argument http-interop middleware?
-     *
-     * @param mixed $middleware
-     * @return bool
-     */
-    private function isInteropMiddleware($middleware)
-    {
-        return ! is_callable($middleware)
-            && $middleware instanceof ServerMiddlewareInterface;
     }
 
     /**

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -518,4 +518,19 @@ class MiddlewarePipeTest extends TestCase
         $this->assertInstanceOf(CallableMiddlewareWrapper::class, $test);
         $this->assertAttributeSame($middleware, 'middleware', $test);
     }
+
+    public function testPipeShouldNotWrapMiddlewarePipeInstancesAsCallableMiddleware()
+    {
+        $nested = new MiddlewarePipe();
+        $pipeline = new MiddlewarePipe();
+
+        $pipeline->pipe($nested);
+
+        $r = new ReflectionProperty($pipeline, 'pipeline');
+        $r->setAccessible(true);
+        $queue = $r->getValue($pipeline);
+
+        $route = $queue->dequeue();
+        $this->assertSame($nested, $route->handler);
+    }
 }


### PR DESCRIPTION
In prepping Expressive to use Stratigility 2, I discovered that `MiddlewarePipe` instances piped into another `MiddlewarePipe` instance were being decorated as callable middleware; this should no longer happen.

This patch adds a test to ensure it does not happen, and updates `pipe()` to not decorate callable `ServerMiddlewareInterface` instances.

In doing so, the `isInteropMiddleware()` method is no longer relevant, and I removed it; since it was marked `private`, this is a backwards compatible change.