### PR TITLE
Code fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,9 +87,6 @@ after_script:
 after_success:
   - if [[ $DEPLOY_DOCS == "true" ]]; then echo "Preparing to build and deploy documentation" ; ./zf-mkdoc-theme/deploy.sh ; echo "Completed deploying documentation" ; fi
 
-after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer upload-coverage ; fi
-
 notifications:
   irc: "irc.freenode.org#zftalk.dev"
   email: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,8 +113,8 @@ Your first step is to establish a public repository from which we can
 pull your work into the master repository. We recommend using
 [GitHub](https://github.com), as that is where the component is already hosted.
 
-1. Setup a [GitHub account](http://github.com/), if you haven't yet
-2. Fork the repository (http://github.com/zendframework/zend-stratigility)
+1. Setup a [GitHub account](https://github.com/), if you haven't yet
+2. Fork the repository (https://github.com/zendframework/zend-stratigility)
 3. Clone the canonical repository locally and enter it.
 
    ```console

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,11 +57,10 @@ To run tests:
 - Install dependencies via composer:
 
   ```console
-  $ curl -sS https://getcomposer.org/installer | php --
   $ composer install
   ```
 
-  If you don't have `curl` installed, you can also download `composer.phar` from https://getcomposer.org/
+  If you don't have `composer` installed, please download it from https://getcomposer.org/download/
 
 - Run the tests using the "test" command shipped in the `composer.json`:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ To run tests:
 
   ```console
   $ git clone git://github.com/zendframework/zend-stratigility.git
-  $ cd
+  $ cd zend-stratigility
   ```
 
 - Install dependencies via composer:

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -57,7 +57,7 @@ class NotFoundHandler implements ServerMiddlewareInterface
         $response = $this->responsePrototype
             ->withStatus(404);
         $response->getBody()->write(sprintf(
-            "Cannot %s %s",
+            'Cannot %s %s',
             $request->getMethod(),
             (string) $request->getUri()
         ));

--- a/src/Next.php
+++ b/src/Next.php
@@ -30,15 +30,6 @@ class Next implements DelegateInterface
     private $queue;
 
     /**
-     * Flag indicating whether or not the dispatcher should raise throwables
-     * when encountered, and whether or not $err arguments should raise them;
-     * defaults false.
-     *
-     * @var bool
-     */
-    private $raiseThrowables = false;
-
-    /**
      * @var string
      */
     private $removed = '';

--- a/src/Next.php
+++ b/src/Next.php
@@ -9,12 +9,10 @@ namespace Zend\Stratigility;
 
 use Interop\Http\ServerMiddleware\DelegateInterface;
 use InvalidArgumentException;
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use SplQueue;
-use Throwable;
 
 /**
  * Iterate a queue of middlewares and execute them.

--- a/test/Exception/InvalidMiddlewareExceptionTest.php
+++ b/test/Exception/InvalidMiddlewareExceptionTest.php
@@ -8,6 +8,7 @@
 namespace ZendTest\Stratigility\Exception;
 
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Zend\Stratigility\Exception\InvalidMiddlewareException;
 
 class InvalidMiddlewareExceptionTest extends TestCase
@@ -23,7 +24,7 @@ class InvalidMiddlewareExceptionTest extends TestCase
             'int'          => [1, 'integer'],
             'float'        => [1.1, 'double'],
             'array'        => [['not', 'callable'], 'array'],
-            'object'       => [(object) ['not', 'callable'], 'stdClass'],
+            'object'       => [(object) ['not', 'callable'], stdClass::class],
         ];
     }
 

--- a/test/Middleware/ErrorHandlerTest.php
+++ b/test/Middleware/ErrorHandlerTest.php
@@ -43,9 +43,6 @@ class ErrorHandlerTest extends TestCase
     public function testReturnsResponseFromDelegateWhenNoProblemsOccur()
     {
         $expectedResponse = $this->prophesize(ResponseInterface::class)->reveal();
-        $innerMiddleware = function ($req) use ($expectedResponse) {
-            return $expectedResponse;
-        };
 
         $this->delegate
             ->process(Argument::type(ServerRequestInterface::class))

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -440,9 +440,6 @@ class MiddlewarePipeTest extends TestCase
         $pipeline = new MiddlewarePipe();
         $pipeline->pipe($middleware->reveal());
 
-        $done = function () {
-        };
-
         $this->assertSame($response->reveal(), $pipeline->process($this->request, $delegate));
     }
 

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -58,7 +58,7 @@ class NextTest extends TestCase
         $this->request->withUri(new Uri('http://local.example.com/bar'));
 
         $next = new Next($this->queue);
-        $next($this->request, $this->response);
+        $next($this->request);
         $this->assertTrue($triggered);
     }
 
@@ -84,7 +84,7 @@ class NextTest extends TestCase
         $this->request->withUri(new Uri('http://local.example.com/foobar'));
 
         $next = new Next($this->queue);
-        $next($this->request, $this->response);
+        $next($this->request);
         $this->assertTrue($triggered);
     }
 
@@ -103,7 +103,7 @@ class NextTest extends TestCase
         $request = $this->request->withUri(new Uri('http://local.example.com/foo'));
 
         $next = new Next($this->queue);
-        $next($request, $this->response);
+        $next($request);
         $this->assertTrue($triggered);
     }
 
@@ -123,7 +123,7 @@ class NextTest extends TestCase
         $request = $this->request->withUri(new Uri('http://local.example.com/foo/bar'));
 
         $next = new Next($this->queue);
-        $next($request, $this->response);
+        $next($request);
         $this->assertEquals('/bar', $triggered);
     }
 
@@ -152,7 +152,7 @@ class NextTest extends TestCase
 
         $request = $this->request->withUri(new Uri('http://example.com/foo/baz/bat'));
         $next = new Next($this->queue);
-        $next($request, $this->response);
+        $next($request);
         $this->assertEquals('done', (string) $this->response->getBody());
     }
 
@@ -182,7 +182,7 @@ class NextTest extends TestCase
 
         $request = $this->request->withUri(new Uri('http://example.com/foo/bar/baz'));
         $next = new Next($this->queue);
-        $result = $next($request, $this->response);
+        $result = $next($request);
         $this->assertSame($this->response, $result);
     }
 
@@ -208,7 +208,7 @@ class NextTest extends TestCase
         $this->queue->enqueue($route2);
 
         $next = new Next($this->queue);
-        $next($request, $this->response);
+        $next($request);
     }
 
     public function testNextShouldRaiseExceptionIfMiddlewareDoesNotReturnResponse()
@@ -232,7 +232,7 @@ class NextTest extends TestCase
         $next    = new Next($this->queue);
 
         $this->expectException(Exception\MissingResponseException::class);
-        $next($request, $this->response);
+        $next($request);
     }
 
     /**

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -50,7 +50,7 @@ class RouteTest extends TestCase
     public function testDoesNotAllowNonStringPaths($path)
     {
         $this->expectException(InvalidArgumentException::class);
-        $route = new Route($path, $this->createEmptyMiddleware());
+        new Route($path, $this->createEmptyMiddleware());
     }
 
     public function testExceptionIsRaisedIfUndefinedPropertyIsAccessed()
@@ -58,6 +58,6 @@ class RouteTest extends TestCase
         $route = new Route('/foo', $this->createEmptyMiddleware());
 
         $this->expectException(OutOfRangeException::class);
-        $foo = $route->foo;
+        $route->foo;
     }
 }


### PR DESCRIPTION
- removed duplicated commands in travis config
- fix contributing guide
- ~updated license to wrap long lines~
- removed unused imports
- removed unused variables
- used single quotation instead of double
- `::class` notation instead of strings
- removed 2nd param in `Next` invocation