### PR TITLE
Added `getPipedPaths()` method

### DIFF
--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -188,6 +188,25 @@ class MiddlewarePipe implements ServerMiddlewareInterface
     }
 
     /**
+     * Returns array of path names that have been passed to `pipe()`
+     *
+     * @param bool $includeRoot  If true, '/' path(s) will be included
+     * @return array
+     */
+    public function getPipedPaths($includeRoot = false)
+    {
+        $paths = [];
+        /* @var Route $route */
+        foreach ($this->pipeline as $route) {
+            if ($route->path != '/' || $includeRoot) {
+                $paths[] = $route->path;
+            }
+        };
+
+        return $paths;
+    }
+
+    /**
      * Normalize a path used when defining a pipe
      *
      * Strips trailing slashes, and prepends a slash.

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -21,6 +21,7 @@ use Zend\Diactoros\Uri;
 use Zend\Stratigility\Exception\InvalidMiddlewareException;
 use Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper;
 use Zend\Stratigility\Middleware\CallableMiddlewareWrapper;
+use Zend\Stratigility\MiddlewareInterface;
 use Zend\Stratigility\MiddlewarePipe;
 use Zend\Stratigility\NoopFinalHandler;
 
@@ -532,5 +533,29 @@ class MiddlewarePipeTest extends TestCase
 
         $route = $queue->dequeue();
         $this->assertSame($nested, $route->handler);
+    }
+
+    public function testGetPipedPathsReturnsPaths()
+    {
+        $piped = $this->prophesize(MiddlewareInterface::class)->reveal();
+        $this->middleware->pipe($piped);
+        $this->middleware->pipe('/first', $piped);
+        $this->middleware->pipe('/second', $piped);
+        $this->middleware->pipe($piped);
+
+        $actual = $this->middleware->getPipedPaths();
+        $this->assertEquals(['/first', '/second'], $actual);
+    }
+
+    public function testGetPipedPathsIncludesRoot()
+    {
+        $piped = $this->prophesize(MiddlewareInterface::class)->reveal();
+        $this->middleware->pipe($piped);
+        $this->middleware->pipe('/first', $piped);
+        $this->middleware->pipe('/second', $piped);
+        $this->middleware->pipe($piped);
+
+        $actual = $this->middleware->getPipedPaths(true);
+        $this->assertEquals(['/', '/first', '/second', '/'], $actual);
     }
 }


### PR DESCRIPTION
As per #101 this PR adds a method for returning the paths that have been added via `MiddlewarePipe::pipe()`