### PR TITLE
spelling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > From "Strata", Latin for "layer", and "agility".
 
-This package supercedes and replaces [phly/conduit](https://github.com/phly/conduit).
+This package supersedes and replaces [phly/conduit](https://github.com/phly/conduit).
 
 Stratigility is a port of [Sencha Connect](https://github.com/senchalabs/connect)
 to PHP. It allows you to create and dispatch middleware pipelines.


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.