### PR TITLE
Remove attribute raiseThrowables because Zend\Stratigility\Next is not using it

### DIFF
--- a/src/Next.php
+++ b/src/Next.php
@@ -32,15 +32,6 @@ class Next implements DelegateInterface
     private $queue;
 
     /**
-     * Flag indicating whether or not the dispatcher should raise throwables
-     * when encountered, and whether or not $err arguments should raise them;
-     * defaults false.
-     *
-     * @var bool
-     */
-    private $raiseThrowables = false;
-
-    /**
      * @var string
      */
     private $removed = '';


### PR DESCRIPTION
Remove attribute raiseThrowables because Zend\Stratigility\Next is not using it.