### PR TITLE
Small fixes on documentation

### DIFF
--- a/doc/book/creating-middleware.md
+++ b/doc/book/creating-middleware.md
@@ -33,8 +33,7 @@ Middleware written in this way can be any of the following:
 - Static class methods
 - PHP array callbacks (e.g., `[ $dispatcher, 'dispatch' ]`, where `$dispatcher` is a class instance)
 - Invokable PHP objects (i.e., instances of classes implementing `__invoke()`)
-- Objects implementing `Zend\Stratigility\MiddlewareInterface` (including
-  `Zend\Stratigility\MiddlewarePipe`)
+- Objects implementing `Zend\Stratigility\MiddlewareInterface`
 
 In all cases, if you wish to implement typehinting, the signature is:
 

--- a/doc/book/middleware.md
+++ b/doc/book/middleware.md
@@ -179,5 +179,4 @@ Within Stratigility, middleware can be:
   `Zend\Stratigility\MiddlewarePipe` implements
   `Interop\Http\ServerMiddleware\MiddlewareInterface`. (Stratigility 2.0 series.)
 - An object implementing `Zend\Stratigility\MiddlewareInterface`.
-  `Zend\Stratigility\MiddlewarePipe` implements this interface.
   (Legacy; this interface is deprecated starting in 1.3.0.)

--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 /**
  * Middleware.
  *
- * Middleware accepts a request and a response, and optionally a
+ * Middleware accepts a request and a response, and a
  * callback `$next` (called if the middleware wants to allow the *next*
  * middleware to process the incoming request, or to delegate output to another
  * process).


### PR DESCRIPTION
- `MiddlewarePipe` does not implement `MIddlewareInterface`
- `callable $next` in `MiddlewareInterface` is not optional