### PR TITLE
Added support for http-interop/http-middleware 0.5.0 (no BC Break)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
   "require": {
     "php": "^5.6 || ^7.0",
     "psr/http-message": "^1.0",
-    "zendframework/zend-escaper": "^2.3",
-    "http-interop/http-middleware": "^0.4.1"
+    "webimpress/http-middleware-compatibility": "^0.1.1",
+    "zendframework/zend-escaper": "^2.3"
   },
   "require-dev": {
     "zendframework/zend-diactoros": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "76a7f787118dd5684fc611a9aaf85ab8",
+    "content-hash": "fc0ee72dfbd4216c2ea1f909b8f5aeef",
     "packages": [
         {
             "name": "http-interop/http-middleware",
@@ -107,6 +107,46 @@
                 "response"
             ],
             "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "webimpress/http-middleware-compatibility",
+            "version": "0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/793d21864a0417bbe01437c33f902cac49c1788c",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c",
+                "shasum": ""
+            },
+            "require": {
+                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.22 || ^6.3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoload/http-middleware.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Compatibility library for Draft PSR-15 HTTP Middleware",
+            "homepage": "https://github.com/webimpress/http-middleware-compatibility",
+            "keywords": [
+                "middleware",
+                "psr-15",
+                "webimpress"
+            ],
+            "time": "2017-10-05T15:55:30+00:00"
         },
         {
             "name": "zendframework/zend-escaper",

--- a/doc/book/api.md
+++ b/doc/book/api.md
@@ -60,8 +60,9 @@ expect the `__invoke()` signature (via the `__invoke()` signature), or stacks
 expecting http-interop middleware signatures (via the `process()` method).
 
 
-When using `__invoke()`, the callable `$out` argument should either be an
-`Interop\Http\Middleware\DelegateInterface`, or use the signature:
+When using `__invoke()`, the callable `$out` argument should either implement
+delegator/request handler interface from `http-interop/http-middleware`
+(depends on version you are using), or use the signature:
 
 ```php
 use Psr\Http\Message\ResponseInterface;
@@ -80,8 +81,8 @@ callback will be provided for you (typically an instance of
 dispatching to the various middleware in its pipeline).
 
 Middleware should either return a response, or the result of
-`$next()/DelegateInterface::process()` (which should eventually evaluate to a
-response instance).
+`$next()/DelegateInterface::process()/RequestHandlerInterface::handle()`
+(which should eventually evaluate to a response instance).
 
 Within Stratigility, `Zend\Stratigility\Next` provides an implementation
 compatible with either usage.

--- a/doc/book/middleware.md
+++ b/doc/book/middleware.md
@@ -178,6 +178,9 @@ Within Stratigility, middleware can be:
 - Any [http-interop 0.4.1 - middleware](https://github.com/http-interop/http-middleware/tree/0.4.1).
   `Zend\Stratigility\MiddlewarePipe` implements
   `Interop\Http\ServerMiddleware\MiddlewareInterface`. (Stratigility 2.0 series.)
+- Any [http-interop 0.5.0 - middleware](https://github.com/http-interop/http-middleware/tree/0.5.0).
+  `Zend\Stratigility\MiddlewarePipe` implements
+  `Interop\Http\Server\MiddlewareInterface`. (Since Stratigility 2.1)
 - An object implementing `Zend\Stratigility\MiddlewareInterface`.
   `Zend\Stratigility\MiddlewarePipe` implements this interface.
   (Legacy; this interface is deprecated starting in 1.3.0.)

--- a/src/Delegate/CallableDelegateDecorator.php
+++ b/src/Delegate/CallableDelegateDecorator.php
@@ -7,9 +7,10 @@
 
 namespace Zend\Stratigility\Delegate;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 
 /**
  * Decorate callable delegates as http-interop delegates in order to process
@@ -38,13 +39,34 @@ class CallableDelegateDecorator implements DelegateInterface
     }
 
     /**
-     * Proxies to the underlying callable delegate to process a request.
+     * Method provided for compatibility with http-interop/http-middleware 0.4.1
      *
      * {@inheritDoc}
      */
     public function process(ServerRequestInterface $request)
     {
+        return $this->handle($request);
+    }
+
+    /**
+     * Proxies to the underlying callable delegate to process a request.
+     *
+     * {@inheritDoc}
+     */
+    public function handle(ServerRequestInterface $request)
+    {
         $delegate = $this->delegate;
         return $delegate($request, $this->response);
+    }
+
+    /**
+     * Method provided for compatibility with http-interop/http-middleware 0.1.1.
+     *
+     * @param RequestInterface $request
+     * @return mixed
+     */
+    public function next(RequestInterface $request)
+    {
+        return $this->handle($request);
     }
 }

--- a/src/Middleware/CallableInteropMiddlewareWrapper.php
+++ b/src/Middleware/CallableInteropMiddlewareWrapper.php
@@ -7,9 +7,9 @@
 
 namespace Zend\Stratigility\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
 class CallableInteropMiddlewareWrapper implements ServerMiddlewareInterface
 {

--- a/src/Middleware/CallableMiddlewareWrapper.php
+++ b/src/Middleware/CallableMiddlewareWrapper.php
@@ -7,11 +7,13 @@
 
 namespace Zend\Stratigility\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Stratigility\Next;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * Decorate legacy callable middleware to make it dispatchable as server
@@ -52,7 +54,7 @@ class CallableMiddlewareWrapper implements ServerMiddlewareInterface
         $delegate = $delegate instanceof Next
             ? $delegate
             : function ($request) use ($delegate) {
-                return $delegate->process($request);
+                return $delegate->{HANDLER_METHOD}($request);
             };
 
         return $middleware($request, $this->responsePrototype, $delegate);

--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -9,13 +9,15 @@ namespace Zend\Stratigility\Middleware;
 
 use ErrorException;
 use Exception;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Stratigility\Delegate\CallableDelegateDecorator;
 use Zend\Stratigility\Exception\MissingResponseException;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * Error handler middleware.
@@ -154,7 +156,7 @@ final class ErrorHandler implements ServerMiddlewareInterface
         set_error_handler($this->createErrorHandler());
 
         try {
-            $response = $delegate->process($request);
+            $response = $delegate->{HANDLER_METHOD}($request);
 
             if (! $response instanceof ResponseInterface) {
                 throw new MissingResponseException('Application did not return a response');

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -7,10 +7,10 @@
 
 namespace Zend\Stratigility\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Stratigility\Delegate\CallableDelegateDecorator;
 
 class NotFoundHandler implements ServerMiddlewareInterface

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -8,13 +8,13 @@
 namespace Zend\Stratigility;
 
 use Closure;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use ReflectionFunction;
 use ReflectionMethod;
 use SplQueue;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Stratigility\Exception\InvalidMiddlewareException;
 
 /**

--- a/src/Route.php
+++ b/src/Route.php
@@ -7,9 +7,9 @@
 
 namespace Zend\Stratigility;
 
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use InvalidArgumentException;
 use OutOfRangeException;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
 /**
  * Value object representing route-based middleware

--- a/test/Middleware/CallableInteropMiddlewareWrapperTest.php
+++ b/test/Middleware/CallableInteropMiddlewareWrapperTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\Stratigility\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/test/Middleware/CallableMiddlewareWrapperTest.php
+++ b/test/Middleware/CallableMiddlewareWrapperTest.php
@@ -8,12 +8,14 @@
 namespace ZendTest\Stratigility\Middleware;
 
 use Closure;
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Stratigility\Middleware\CallableMiddlewareWrapper;
 use Zend\Stratigility\Next;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class CallableMiddlewareWrapperTest extends TestCase
 {
@@ -75,7 +77,7 @@ class CallableMiddlewareWrapperTest extends TestCase
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request)->willReturn($expected);
+        $delegate->{HANDLER_METHOD}($request)->willReturn($expected);
 
         $decorator = new CallableMiddlewareWrapper(
             function ($request, $response, $next) {

--- a/test/Middleware/ErrorHandlerTest.php
+++ b/test/Middleware/ErrorHandlerTest.php
@@ -7,16 +7,18 @@
 
 namespace ZendTest\Stratigility\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Escaper\Escaper;
 use Zend\Stratigility\Middleware\ErrorHandler;
 use Zend\Stratigility\Middleware\ErrorResponseGenerator;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class ErrorHandlerTest extends TestCase
 {
@@ -45,7 +47,7 @@ class ErrorHandlerTest extends TestCase
         $expectedResponse = $this->prophesize(ResponseInterface::class)->reveal();
 
         $this->delegate
-            ->process(Argument::type(ServerRequestInterface::class))
+            ->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))
             ->willReturn($expectedResponse);
 
         $this->response->withStatus(Argument::any())->shouldNotBeCalled();
@@ -59,7 +61,7 @@ class ErrorHandlerTest extends TestCase
     public function testReturnsErrorResponseIfDelegateDoesNotReturnAResponse()
     {
         $this->delegate
-            ->process(Argument::type(ServerRequestInterface::class))
+            ->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))
             ->willReturn(null);
 
         $this->body->write('Unknown Error')->shouldBeCalled();
@@ -78,7 +80,7 @@ class ErrorHandlerTest extends TestCase
     {
         error_reporting(E_USER_DEPRECATED);
         $this->delegate
-            ->process(Argument::type(ServerRequestInterface::class))
+            ->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))
             ->will(function () {
                 trigger_error('Deprecated', E_USER_DEPRECATED);
             });
@@ -102,7 +104,7 @@ class ErrorHandlerTest extends TestCase
 
         $expectedResponse = $this->prophesize(ResponseInterface::class)->reveal();
         $this->delegate
-            ->process(Argument::type(ServerRequestInterface::class))
+            ->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))
             ->will(function () use ($expectedResponse) {
                 trigger_error('Deprecated', E_USER_DEPRECATED);
                 return $expectedResponse;
@@ -121,7 +123,7 @@ class ErrorHandlerTest extends TestCase
     public function testReturnsErrorResponseIfDelegateRaisesAnException()
     {
         $this->delegate
-            ->process(Argument::type(ServerRequestInterface::class))
+            ->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))
             ->willThrow(new RuntimeException('Exception raised', 503));
 
         $this->body->write('Unknown Error')->shouldBeCalled();
@@ -140,7 +142,7 @@ class ErrorHandlerTest extends TestCase
     {
         $exception = new RuntimeException('Exception raised', 503);
         $this->delegate
-            ->process(Argument::type(ServerRequestInterface::class))
+            ->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))
             ->willThrow($exception);
 
         $this->body
@@ -161,7 +163,7 @@ class ErrorHandlerTest extends TestCase
     {
         $exception = new RuntimeException('Exception raised', 503);
         $this->delegate
-            ->process(Argument::type(ServerRequestInterface::class))
+            ->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))
             ->willThrow($exception);
 
         $this->body->write('Unknown Error')->shouldBeCalled();
@@ -195,7 +197,7 @@ class ErrorHandlerTest extends TestCase
         };
 
         $this->delegate
-            ->process(Argument::type(ServerRequestInterface::class))
+            ->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))
             ->willThrow(new RuntimeException('Exception raised', 503));
 
         $this->response->withStatus(400)->will([$this->response, 'reveal']);

--- a/test/Middleware/NotFoundHandlerTest.php
+++ b/test/Middleware/NotFoundHandlerTest.php
@@ -7,11 +7,11 @@
 
 namespace ZendTest\Stratigility\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Stratigility\Middleware\NotFoundHandler;
 
 class NotFoundHandlerTest extends TestCase

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -7,22 +7,23 @@
 
 namespace ZendTest\Stratigility;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use ReflectionProperty;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest as Request;
 use Zend\Diactoros\Uri;
 use Zend\Stratigility\Exception\InvalidMiddlewareException;
-use Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper;
 use Zend\Stratigility\Middleware\CallableMiddlewareWrapper;
 use Zend\Stratigility\MiddlewarePipe;
 use Zend\Stratigility\NoopFinalHandler;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class MiddlewarePipeTest extends TestCase
 {
@@ -111,7 +112,7 @@ class MiddlewarePipeTest extends TestCase
         $request = new Request([], [], 'http://local.example.com/foo', 'GET', 'php://memory');
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request)->willReturn($expected);
+        $delegate->{HANDLER_METHOD}($request)->willReturn($expected);
 
         $result = $this->middleware->__invoke($request, $this->response, $delegate->reveal());
 
@@ -215,7 +216,7 @@ class MiddlewarePipeTest extends TestCase
 
         $request = new Request([], [], 'http://local.example.com/test', 'GET', 'php://memory');
         $final = $this->prophesize(DelegateInterface::class);
-        $final->process(Argument::any())->shouldNotBeCalled();
+        $final->{HANDLER_METHOD}(Argument::any())->shouldNotBeCalled();
 
         $result = $pipeline->process($request, $final->reveal());
         $this->assertSame($expected, $result);
@@ -481,7 +482,7 @@ class MiddlewarePipeTest extends TestCase
 
         $route = $queue->dequeue();
         $test = $route->handler;
-        $this->assertInstanceOf(CallableInteropMiddlewareWrapper::class, $test);
+        $this->assertInstanceOf(CallableMiddlewareWrapper::class, $test);
         $this->assertAttributeSame($middleware, 'middleware', $test);
     }
 

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -7,8 +7,6 @@
 
 namespace ZendTest\Stratigility;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -16,6 +14,8 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionProperty;
 use SplQueue;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest as Request;
 use Zend\Diactoros\Uri;

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\Stratigility;
 
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use InvalidArgumentException;
 use OutOfRangeException;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
We keep also support for previous version. Now it depends on the library consumer what version of http-middleware to use. We accomplish that by using external library `webimpress/http-middleware-compatibility`.

Please note that tests runs with lowest/locked/latest dependencies. I've set `composer.lock` on http-middleware 0.4.1, lowest will be 0.1.1 and latest 0.5.0. All test pass :)

Probably we don't need support version http-middleware 0.1.1 anymore, so can add conflict condition in composer. To support it, I've added in two place method `next` as proxy to method `handle` (also new method, to support http-middleware 0.5.0) - and now `process` is proxy to `handle`.

Definitely we need update documentation a bit more. I'm thinking about all examples in documentation. How we should do that? Use always `http-middleware` interfaces (what version?) or aliases from `webimpress/http-middleware-compatibility`? IMHO, final library users should use http-middleware interfaces directly.