### PR TITLE
Added http-server-middleware support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,14 @@ env:
   global:
     - COMPOSER_ARGS="--no-interaction --no-plugins"
     - COVERAGE_DEPS="satooshi/php-coveralls"
+    - HTTP_INTEROP_MIDDLEWARE="http-interop/http-middleware:^0.5"
 
 matrix:
   include:
     - php: 5.6
       env:
         - DEPS=lowest
+        - HTTP_INTEROP_MIDDLEWARE="http-interop/http-middleware:^0.4.1"
     - php: 5.6
       env:
         - LEGACY_DEPS="phpunit/phpunit"
@@ -26,6 +28,7 @@ matrix:
     - php: 7
       env:
         - DEPS=lowest
+        - HTTP_INTEROP_MIDDLEWARE="http-interop/http-middleware:^0.4.1"
     - php: 7
       env:
         - DEPS=locked
@@ -35,26 +38,29 @@ matrix:
     - php: 7
       env:
         - DEPS=latest
+        - HTTP_INTEROP_MIDDLEWARE="http-interop/http-server-middleware:^1.0.1"
     - php: 7.1
       env:
         - DEPS=lowest
+        - HTTP_INTEROP_MIDDLEWARE="http-interop/http-middleware:^0.4.1"
     - php: 7.1
       env:
         - DEPS=locked
     - php: 7.1
       env:
         - DEPS=latest
+        - HTTP_INTEROP_MIDDLEWARE="http-interop/http-server-middleware:^1.0.1"
     - php: 7.2
       env:
         - DEPS=lowest
+        - HTTP_INTEROP_MIDDLEWARE="http-interop/http-middleware:^0.4.1"
     - php: 7.2
       env:
         - DEPS=locked
     - php: 7.2
       env:
         - DEPS=latest
-  allow_failures:
-    - php: 7.2
+        - HTTP_INTEROP_MIDDLEWARE="http-interop/http-server-middleware:^1.0.1"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' && "$(php --version | grep xdebug -ci)" -ge 1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
@@ -66,6 +72,7 @@ install:
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
+  - travis_retry composer require $COMPOSER_ARGS $HTTP_INTEROP_MIDDLEWARE
   - stty cols 120 && composer show
 
 script:

--- a/autoload/http-interop.php
+++ b/autoload/http-interop.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+use const Webimpress\HttpMiddlewareCompatibility\HAS_RETURN_TYPE;
+
+$classes = [
+    \Zend\Stratigility\Delegate\CallableDelegateDecorator::class,
+    \Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper::class,
+    \Zend\Stratigility\Middleware\CallableMiddlewareWrapper::class,
+    \Zend\Stratigility\Middleware\ErrorHandler::class,
+    \Zend\Stratigility\Middleware\NotFoundHandler::class,
+    \Zend\Stratigility\MiddlewarePipe::class,
+    \Zend\Stratigility\Next::class,
+];
+
+$suffix = HAS_RETURN_TYPE ? 'WithReturnType' : 'WithoutReturnType';
+
+foreach ($classes as $class) {
+    class_alias($class . $suffix, $class);
+}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require": {
     "php": "^5.6 || ^7.0",
     "psr/http-message": "^1.0",
-    "webimpress/http-middleware-compatibility": "^0.1.3",
+    "webimpress/http-middleware-compatibility": "dev-feature/http-server-middleware as 0.2",
     "zendframework/zend-escaper": "^2.3"
   },
   "require-dev": {
@@ -44,6 +44,9 @@
     "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Stratigility; e.g., zendframework/zend-diactoros"
   },
   "autoload": {
+    "files": [
+      "autoload/http-interop.php"
+    ],
     "psr-4": {
       "Zend\\Stratigility\\": "src/"
     }
@@ -53,6 +56,7 @@
       "ZendTest\\Stratigility\\": "test/"
     }
   },
+  "minimum-stability": "dev",
   "scripts": {
     "check": [
       "@license-check",

--- a/composer.lock
+++ b/composer.lock
@@ -4,60 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d06efb434935f2b83caf9691f7abcb2b",
+    "content-hash": "0bc4bc532c751b23881954a6e5a65e3f",
     "packages": [
-        {
-            "name": "http-interop/http-middleware",
-            "version": "0.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/9a801fe60e70d5d608b61d56b2dcde29516c81b9",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0",
-                "psr/http-message": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Http\\ServerMiddleware\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP server-side middleware",
-            "keywords": [
-                "factory",
-                "http",
-                "middleware",
-                "psr",
-                "psr-17",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "time": "2017-01-14T15:23:42+00:00"
-        },
         {
             "name": "psr/http-message",
             "version": "1.0.1",
@@ -110,16 +58,16 @@
         },
         {
             "name": "webimpress/composer-extra-dependency",
-            "version": "0.2.0",
+            "version": "dev-feature/dependency-or",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/composer-extra-dependency.git",
-                "reference": "97c241b2c80628a2cd1002cece3fc54c419b1776"
+                "reference": "0a17a77a364dbafe923b0277f4e95c8243a764d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/97c241b2c80628a2cd1002cece3fc54c419b1776",
-                "reference": "97c241b2c80628a2cd1002cece3fc54c419b1776",
+                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/0a17a77a364dbafe923b0277f4e95c8243a764d9",
+                "reference": "0a17a77a364dbafe923b0277f4e95c8243a764d9",
                 "shasum": ""
             },
             "require": {
@@ -152,35 +100,37 @@
                 "dependency",
                 "webimpress"
             ],
-            "time": "2017-10-11T22:05:48+00:00"
+            "time": "2017-11-13T07:36:32+00:00"
         },
         {
             "name": "webimpress/http-middleware-compatibility",
-            "version": "0.1.3",
+            "version": "dev-feature/http-server-middleware",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/http-middleware-compatibility.git",
-                "reference": "5839f5abf54346eafa6617434bd5f618c0cc7adb"
+                "reference": "b39b3554a974969c159046fa4c4694030b5bf414"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/5839f5abf54346eafa6617434bd5f618c0cc7adb",
-                "reference": "5839f5abf54346eafa6617434bd5f618c0cc7adb",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/b39b3554a974969c159046fa4c4694030b5bf414",
+                "reference": "b39b3554a974969c159046fa4c4694030b5bf414",
                 "shasum": ""
             },
             "require": {
-                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
                 "php": "^5.6 || ^7.0",
-                "webimpress/composer-extra-dependency": "^0.2"
+                "webimpress/composer-extra-dependency": "dev-feature/dependency-or as 0.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7.22 || ^6.3.1"
+                "phpunit/phpunit": "^5.7.23 || ^6.4.4"
             },
             "type": "library",
             "extra": {
-                "dependency": [
-                    "http-interop/http-middleware"
-                ]
+                "dependency-or": {
+                    "What middleware package would you like to use?": [
+                        "http-interop/http-middleware",
+                        "http-interop/http-server-middleware"
+                    ]
+                }
             },
             "autoload": {
                 "files": [
@@ -198,7 +148,7 @@
                 "psr-15",
                 "webimpress"
             ],
-            "time": "2017-10-11T22:13:48+00:00"
+            "time": "2017-11-12T22:07:52+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -2178,9 +2128,18 @@
             "time": "2017-01-23T04:53:24+00:00"
         }
     ],
-    "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": [],
+    "aliases": [
+        {
+            "alias": "0.2",
+            "alias_normalized": "0.2.0.0",
+            "version": "dev-feature/http-server-middleware",
+            "package": "webimpress/http-middleware-compatibility"
+        }
+    ],
+    "minimum-stability": "dev",
+    "stability-flags": {
+        "webimpress/http-middleware-compatibility": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Delegate/CallableDelegateDecoratorTrait.php
+++ b/src/Delegate/CallableDelegateDecoratorTrait.php
@@ -10,13 +10,14 @@ namespace Zend\Stratigility\Delegate;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 
 /**
  * Decorate callable delegates as http-interop delegates in order to process
  * incoming requests.
+ *
+ * @internal
  */
-class CallableDelegateDecorator implements DelegateInterface
+trait CallableDelegateDecoratorTrait
 {
     /**
      * @var callable

--- a/src/Delegate/CallableDelegateDecoratorWithReturnType.php
+++ b/src/Delegate/CallableDelegateDecoratorWithReturnType.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 
+/**
+ * @internal
+ */
 class CallableDelegateDecoratorWithReturnType implements DelegateInterface
 {
     use CallableDelegateDecoratorTrait {

--- a/src/Delegate/CallableDelegateDecoratorWithReturnType.php
+++ b/src/Delegate/CallableDelegateDecoratorWithReturnType.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Delegate;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+
+class CallableDelegateDecoratorWithReturnType implements DelegateInterface
+{
+    use CallableDelegateDecoratorTrait {
+        handle as handleTrait;
+    }
+
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        return $this->handleTrait($request);
+    }
+}

--- a/src/Delegate/CallableDelegateDecoratorWithoutReturnType.php
+++ b/src/Delegate/CallableDelegateDecoratorWithoutReturnType.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 
+/**
+ * @internal
+ */
 class CallableDelegateDecoratorWithoutReturnType implements DelegateInterface
 {
     use CallableDelegateDecoratorTrait {

--- a/src/Delegate/CallableDelegateDecoratorWithoutReturnType.php
+++ b/src/Delegate/CallableDelegateDecoratorWithoutReturnType.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Delegate;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+
+class CallableDelegateDecoratorWithoutReturnType implements DelegateInterface
+{
+    use CallableDelegateDecoratorTrait {
+        handle as handleTrait;
+    }
+
+    public function handle(ServerRequestInterface $request)
+    {
+        return $this->handleTrait($request);
+    }
+}

--- a/src/Middleware/CallableInteropMiddlewareWrapperTrait.php
+++ b/src/Middleware/CallableInteropMiddlewareWrapperTrait.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+
+/**
+ * @internal
+ */
+trait CallableInteropMiddlewareWrapperTrait
+{
+    /**
+     * @param callable
+     */
+    private $middleware;
+
+    /**
+     * @param callable $middleware
+     */
+    public function __construct(callable $middleware)
+    {
+        $this->middleware = $middleware;
+    }
+
+    /**
+     * {@inheritDocs}
+     */
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        $middleware = $this->middleware;
+        return $middleware($request, $delegate);
+    }
+}

--- a/src/Middleware/CallableInteropMiddlewareWrapperWithReturnType.php
+++ b/src/Middleware/CallableInteropMiddlewareWrapperWithReturnType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
+
+class CallableInteropMiddlewareWrapperWithReturnType implements ServerMiddlewareInterface
+{
+    use CallableInteropMiddlewareWrapperTrait {
+        process as processTrait;
+    }
+
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface
+    {
+        return $this->processTrait($request, $delegate);
+    }
+}

--- a/src/Middleware/CallableInteropMiddlewareWrapperWithReturnType.php
+++ b/src/Middleware/CallableInteropMiddlewareWrapperWithReturnType.php
@@ -12,6 +12,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
+/**
+ * @internal
+ */
 class CallableInteropMiddlewareWrapperWithReturnType implements ServerMiddlewareInterface
 {
     use CallableInteropMiddlewareWrapperTrait {

--- a/src/Middleware/CallableInteropMiddlewareWrapperWithoutReturnType.php
+++ b/src/Middleware/CallableInteropMiddlewareWrapperWithoutReturnType.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
+/**
+ * @internal
+ */
 class CallableInteropMiddlewareWrapperWithoutReturnType implements ServerMiddlewareInterface
 {
     use CallableInteropMiddlewareWrapperTrait {

--- a/src/Middleware/CallableInteropMiddlewareWrapperWithoutReturnType.php
+++ b/src/Middleware/CallableInteropMiddlewareWrapperWithoutReturnType.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
+
+class CallableInteropMiddlewareWrapperWithoutReturnType implements ServerMiddlewareInterface
+{
+    use CallableInteropMiddlewareWrapperTrait {
+        process as processTrait;
+    }
+
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        return $this->processTrait($request, $delegate);
+    }
+}

--- a/src/Middleware/CallableMiddlewareWrapperTrait.php
+++ b/src/Middleware/CallableMiddlewareWrapperTrait.php
@@ -18,8 +18,10 @@ use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 /**
  * Decorate legacy callable middleware to make it dispatchable as server
  * middleware.
+ *
+ * @internal
  */
-class CallableMiddlewareWrapper implements ServerMiddlewareInterface
+trait CallableMiddlewareWrapperTrait
 {
     /**
      * @var callable

--- a/src/Middleware/CallableMiddlewareWrapperWithReturnType.php
+++ b/src/Middleware/CallableMiddlewareWrapperWithReturnType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
+
+class CallableMiddlewareWrapperWithReturnType implements ServerMiddlewareInterface
+{
+    use CallableMiddlewareWrapperTrait {
+        process as processTrait;
+    }
+
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface
+    {
+        return $this->processTrait($request, $delegate);
+    }
+}

--- a/src/Middleware/CallableMiddlewareWrapperWithReturnType.php
+++ b/src/Middleware/CallableMiddlewareWrapperWithReturnType.php
@@ -12,6 +12,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
+/**
+ * @internal
+ */
 class CallableMiddlewareWrapperWithReturnType implements ServerMiddlewareInterface
 {
     use CallableMiddlewareWrapperTrait {

--- a/src/Middleware/CallableMiddlewareWrapperWithoutReturnType.php
+++ b/src/Middleware/CallableMiddlewareWrapperWithoutReturnType.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
+/**
+ * @internal
+ */
 class CallableMiddlewareWrapperWithoutReturnType implements ServerMiddlewareInterface
 {
     use CallableMiddlewareWrapperTrait {

--- a/src/Middleware/CallableMiddlewareWrapperWithoutReturnType.php
+++ b/src/Middleware/CallableMiddlewareWrapperWithoutReturnType.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
+
+class CallableMiddlewareWrapperWithoutReturnType implements ServerMiddlewareInterface
+{
+    use CallableMiddlewareWrapperTrait {
+        process as processTrait;
+    }
+
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        return $this->processTrait($request, $delegate);
+    }
+}

--- a/src/Middleware/ErrorHandlerTrait.php
+++ b/src/Middleware/ErrorHandlerTrait.php
@@ -64,8 +64,10 @@ use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
  *
  * Listeners are attached using the attachListener() method, and triggered
  * in the order attached.
+ *
+ * @internal
  */
-final class ErrorHandler implements ServerMiddlewareInterface
+trait ErrorHandlerTrait
 {
     /**
      * @var callable[]

--- a/src/Middleware/ErrorHandlerWithReturnType.php
+++ b/src/Middleware/ErrorHandlerWithReturnType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
+
+class ErrorHandlerWithReturnType implements ServerMiddlewareInterface
+{
+    use ErrorHandlerTrait {
+        process as processTrait;
+    }
+
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface
+    {
+        return $this->processTrait($request, $delegate);
+    }
+}

--- a/src/Middleware/ErrorHandlerWithReturnType.php
+++ b/src/Middleware/ErrorHandlerWithReturnType.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
-class ErrorHandlerWithReturnType implements ServerMiddlewareInterface
+final class ErrorHandlerWithReturnType implements ServerMiddlewareInterface
 {
     use ErrorHandlerTrait {
         process as processTrait;

--- a/src/Middleware/ErrorHandlerWithReturnType.php
+++ b/src/Middleware/ErrorHandlerWithReturnType.php
@@ -12,6 +12,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
+/**
+ * @internal
+ */
 final class ErrorHandlerWithReturnType implements ServerMiddlewareInterface
 {
     use ErrorHandlerTrait {

--- a/src/Middleware/ErrorHandlerWithoutReturnType.php
+++ b/src/Middleware/ErrorHandlerWithoutReturnType.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
+
+class ErrorHandlerWithoutReturnType implements ServerMiddlewareInterface
+{
+    use ErrorHandlerTrait {
+        process as processTrait;
+    }
+
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        return $this->processTrait($request, $delegate);
+    }
+}

--- a/src/Middleware/ErrorHandlerWithoutReturnType.php
+++ b/src/Middleware/ErrorHandlerWithoutReturnType.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
-class ErrorHandlerWithoutReturnType implements ServerMiddlewareInterface
+final class ErrorHandlerWithoutReturnType implements ServerMiddlewareInterface
 {
     use ErrorHandlerTrait {
         process as processTrait;

--- a/src/Middleware/ErrorHandlerWithoutReturnType.php
+++ b/src/Middleware/ErrorHandlerWithoutReturnType.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
+/**
+ * @internal
+ */
 final class ErrorHandlerWithoutReturnType implements ServerMiddlewareInterface
 {
     use ErrorHandlerTrait {

--- a/src/Middleware/NotFoundHandlerTrait.php
+++ b/src/Middleware/NotFoundHandlerTrait.php
@@ -13,7 +13,10 @@ use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Stratigility\Delegate\CallableDelegateDecorator;
 
-class NotFoundHandler implements ServerMiddlewareInterface
+/**
+ * @internal
+ */
+trait NotFoundHandlerTrait
 {
     /**
      * @var ResponseInterface

--- a/src/Middleware/NotFoundHandlerWithReturnType.php
+++ b/src/Middleware/NotFoundHandlerWithReturnType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
+
+class NotFoundHandlerWithReturnType implements ServerMiddlewareInterface
+{
+    use NotFoundHandlerTrait {
+        process as processTrait;
+    }
+
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface
+    {
+        return $this->processTrait($request, $delegate);
+    }
+}

--- a/src/Middleware/NotFoundHandlerWithReturnType.php
+++ b/src/Middleware/NotFoundHandlerWithReturnType.php
@@ -12,6 +12,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
+/**
+ * @internal
+ */
 class NotFoundHandlerWithReturnType implements ServerMiddlewareInterface
 {
     use NotFoundHandlerTrait {

--- a/src/Middleware/NotFoundHandlerWithoutReturnType.php
+++ b/src/Middleware/NotFoundHandlerWithoutReturnType.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 
@@ -11,27 +11,14 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
-class CallableInteropMiddlewareWrapper implements ServerMiddlewareInterface
+class NotFoundHandlerWithoutReturnType implements ServerMiddlewareInterface
 {
-    /**
-     * @param callable
-     */
-    private $middleware;
-
-    /**
-     * @param callable $middleware
-     */
-    public function __construct(callable $middleware)
-    {
-        $this->middleware = $middleware;
+    use NotFoundHandlerTrait {
+        process as processTrait;
     }
 
-    /**
-     * {@inheritDocs}
-     */
     public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
-        $middleware = $this->middleware;
-        return $middleware($request, $delegate);
+        return $this->processTrait($request, $delegate);
     }
 }

--- a/src/Middleware/NotFoundHandlerWithoutReturnType.php
+++ b/src/Middleware/NotFoundHandlerWithoutReturnType.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
+/**
+ * @internal
+ */
 class NotFoundHandlerWithoutReturnType implements ServerMiddlewareInterface
 {
     use NotFoundHandlerTrait {

--- a/src/MiddlewarePipeTrait.php
+++ b/src/MiddlewarePipeTrait.php
@@ -30,8 +30,9 @@ use Zend\Stratigility\Exception\InvalidMiddlewareException;
  * Inspired by Sencha Connect.
  *
  * @see https://github.com/sencha/connect
+ * @internal
  */
-class MiddlewarePipe implements ServerMiddlewareInterface
+trait MiddlewarePipeTrait
 {
     /**
      * @var Middleware\CallableMiddlewareWrapperFactory

--- a/src/MiddlewarePipeWithReturnType.php
+++ b/src/MiddlewarePipeWithReturnType.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
+
+class MiddlewarePipeWithReturnType implements ServerMiddlewareInterface
+{
+    use MiddlewarePipeTrait {
+        process as processTrait;
+    }
+
+    /**
+     * http-interop invocation: single-pass with delegate.
+     *
+     * Executes the internal pipeline, passing $delegate as the "final
+     * handler" in cases when the pipeline exhausts itself.
+     *
+     * @param ServerRequestInterface $request
+     * @param DelegateInterface $delegate
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface
+    {
+        return $this->processTrait($request, $delegate);
+    }
+}

--- a/src/MiddlewarePipeWithReturnType.php
+++ b/src/MiddlewarePipeWithReturnType.php
@@ -12,6 +12,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
+/**
+ * @internal
+ */
 class MiddlewarePipeWithReturnType implements ServerMiddlewareInterface
 {
     use MiddlewarePipeTrait {

--- a/src/MiddlewarePipeWithoutReturnType.php
+++ b/src/MiddlewarePipeWithoutReturnType.php
@@ -12,6 +12,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
+/**
+ * @internal
+ */
 class MiddlewarePipeWithoutReturnType implements ServerMiddlewareInterface
 {
     use MiddlewarePipeTrait {

--- a/src/MiddlewarePipeWithoutReturnType.php
+++ b/src/MiddlewarePipeWithoutReturnType.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
+
+class MiddlewarePipeWithoutReturnType implements ServerMiddlewareInterface
+{
+    use MiddlewarePipeTrait {
+        process as processTrait;
+    }
+
+    /**
+     * http-interop invocation: single-pass with delegate.
+     *
+     * Executes the internal pipeline, passing $delegate as the "final
+     * handler" in cases when the pipeline exhausts itself.
+     *
+     * @param ServerRequestInterface $request
+     * @param DelegateInterface $delegate
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        return $this->processTrait($request, $delegate);
+    }
+}

--- a/src/NextTrait.php
+++ b/src/NextTrait.php
@@ -19,8 +19,10 @@ use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * Iterate a queue of middlewares and execute them.
+ *
+ * @internal
  */
-class Next implements DelegateInterface
+trait NextTrait
 {
     /**
      * @var null|DelegateInterface
@@ -141,7 +143,11 @@ class Next implements DelegateInterface
         }
 
         $middleware = $layer->handler;
-        $response = $middleware->process($request, $this);
+        try {
+            $response = $middleware->process($request, $this);
+        } catch (\TypeError $e) {
+            $response = null;
+        }
 
         if (! $response instanceof ResponseInterface) {
             throw new Exception\MissingResponseException(sprintf(

--- a/src/NextWithReturnType.php
+++ b/src/NextWithReturnType.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+
+class NextWithReturnType implements DelegateInterface
+{
+    use NextTrait {
+        handle as handleTrait;
+    }
+
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        return $this->handleTrait($request);
+    }
+}

--- a/src/NextWithReturnType.php
+++ b/src/NextWithReturnType.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 
+/**
+ * @internal
+ */
 class NextWithReturnType implements DelegateInterface
 {
     use NextTrait {

--- a/src/NextWithoutReturnType.php
+++ b/src/NextWithoutReturnType.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+
+class NextWithoutReturnType implements DelegateInterface
+{
+    use NextTrait {
+        handle as handleTrait;
+    }
+
+    public function handle(ServerRequestInterface $request)
+    {
+        return $this->handleTrait($request);
+    }
+}

--- a/src/NextWithoutReturnType.php
+++ b/src/NextWithoutReturnType.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 
+/**
+ * @internal
+ */
 class NextWithoutReturnType implements DelegateInterface
 {
     use NextTrait {


### PR DESCRIPTION
This PR provides smooth path update from `http-middleware` to `http-server-middleware`.
Unfortunately it's very complicated... And I don't like it at all...

I think much easier will be release 3.0.0 (see PR #122) or wait for final version of PSR-15...