### PR TITLE
Adds PSR-15 decorator classes for callable middleware

### DIFF
--- a/docs/book/api.md
+++ b/docs/book/api.md
@@ -173,7 +173,56 @@ your users.
 
 Stratigility provides several concrete middleware implementations.
 
-#### ErrorHandler and NotFoundHandler
+### CallableMiddlewareDecorator
+
+`Zend\Stratigility\Middleware\CallableMiddlewareDecorator` provides the ability
+to decorate PHP callables that have the same signature as or a compatible
+signature to PSR-15's `MiddlewareInterface`. This allows for one-off middleware
+creation when creating your pipeline:
+
+```php
+$pipeline->pipe(new CallableMiddlewareDecorator(function ($req, $handler) {
+    // do some work
+    $response = $next($req, $handler);
+    // do some work
+    return $response;
+});
+```
+
+### DoublePassMiddlewareDecorator
+
+`Zend\Stratigility\Middleware\DoublePassMiddlewareDecorator` provides the
+ability to decorate "double-pass", callable middleware (so-called because you
+pass the request _and_ response to the delegate) within a class implementing the
+PSR-15 `MiddlewareInterface`. This allows you to adapt existing middleware with
+the double-pass interface to work with Stratigility.
+
+```php
+$pipeline->pipe(new DoublePassMiddlewareDecorator(function ($req, $res, $next) {
+    // do some work
+    $response = $next($req, $res);
+    // do some work
+    return $response;
+});
+```
+
+`$next` is a callable that decorates Stratigility's `Next` instance; it
+ignores the response argument.
+
+The constructor takes an optional second argument, a response prototype. This
+will be used to pass to the middleware when it is executed. If no instance is
+provided, a zend-diactoros response instance is auto-wired. If you want to use
+an alternate PSR-7 `ResponseInterface` implementation, pass it when creating the
+decorator instance:
+
+```php
+$pipeline->pipe(new DoublePassMiddlewareDecorator(
+    $doublePassMiddleware,
+    $response
+));
+```
+
+### ErrorHandler and NotFoundHandler
 
 These two middleware allow you to provide handle PHP errors and exceptions, and
 404 conditions, respectively. You may read more about them in the

--- a/src/Exception/MissingResponseException.php
+++ b/src/Exception/MissingResponseException.php
@@ -15,4 +15,15 @@ use OutOfBoundsException;
  */
 class MissingResponseException extends OutOfBoundsException
 {
+    public static function forCallableMiddleware(callable $middleware) : self
+    {
+        $type = is_object($middleware)
+            ? get_class($middleware)
+            : gettype($middleware);
+
+        return new self(sprintf(
+            'Decorated callable middleware of type %s failed to produce a response.',
+            $type
+        ));
+    }
 }

--- a/src/Exception/MissingResponsePrototypeException.php
+++ b/src/Exception/MissingResponsePrototypeException.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Exception;
+
+use UnexpectedValueException;
+use Zend\Stratigility\Middleware\DoublePassMiddlewareWrapper;
+
+/**
+ * Exception thrown by the DoublePassMiddlewareWrapper when no response
+ * prototype is provided, and Diactoros is not available to create a default.
+ */
+class MissingResponsePrototypeException extends UnexpectedValueException
+{
+    public static function create() : self
+    {
+        return new self(sprintf(
+            'Unable to create a %s instance; no response prototype provided,'
+            . ' and zendframework/zend-diactoros is not installed',
+            DoublePassMiddlewareWrapper::class
+        ));
+    }
+}

--- a/src/Middleware/CallableMiddlewareDecorator.php
+++ b/src/Middleware/CallableMiddlewareDecorator.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Stratigility\Exception;
+
+/**
+ * Decorate callable middleware as PSR-15 middleware.
+ *
+ * Decorates middleware with the following signature:
+ *
+ * <code>
+ * function (
+ *     ServerRequestInterface $request,
+ *     RequestHandlerInterface $handler
+ * ) : ResponseInterface
+ * </code>
+ *
+ * such that it will operate as PSR-15 middleware.
+ *
+ * Neither the arguments nor the return value need be typehinted; however, if
+ * the signature is incompatible, a PHP Error will likely be thrown.
+ */
+class CallableMiddlewareDecorator implements MiddlewareInterface
+{
+    /**
+     * @var callable
+     */
+    private $middleware;
+
+    public function __construct(callable $middleware)
+    {
+        $this->middleware = $middleware;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws Exception\MissingResponseException if the decorated middleware
+     *     fails to produce a response.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        $response = ($this->middleware)($request, $handler);
+        if (! $response instanceof ResponseInterface) {
+            throw Exception\MissingResponseException::forCallableMiddleware($this->middleware);
+        }
+        return $response;
+    }
+}

--- a/src/Middleware/DoublePassMiddlewareDecorator.php
+++ b/src/Middleware/DoublePassMiddlewareDecorator.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response;
+use Zend\Stratigility\Exception;
+
+/**
+ * Decorate double-pass middleware as PSR-15 middleware.
+ *
+ * Decorates middleware with the following signature:
+ *
+ * <code>
+ * function (
+ *     ServerRequestInterface $request,
+ *     ResponseInterface $response,
+ *     callable $next
+ * ) : ResponseInterface
+ * </code>
+ *
+ * such that it will operate as PSR-15 middleware.
+ *
+ * Neither the arguments nor the return value need be typehinted; however, if
+ * the signature is incompatible, a PHP Error will likely be thrown.
+ */
+class DoublePassMiddlewareDecorator implements MiddlewareInterface
+{
+    /**
+     * @var callable
+     */
+    private $middleware;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    /**
+     * @throws Exception\MissingResponsePrototypeException if no response
+     *     prototype is present, and zend-diactoros is not installed.
+     */
+    public function __construct(callable $middleware, ResponseInterface $responsePrototype = null)
+    {
+        $this->middleware = $middleware;
+
+        if (! $responsePrototype && ! class_exists(Response::class)) {
+            throw Exception\MissingResponsePrototypeException::create();
+        }
+
+        $this->responsePrototype = $responsePrototype ?? new Response();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws Exception\MissingResponseException if the decorated middleware
+     *     fails to produce a response.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        $response = ($this->middleware)(
+            $request,
+            $this->responsePrototype,
+            $this->decorateHandler($handler)
+        );
+
+        if (! $response instanceof ResponseInterface) {
+            throw Exception\MissingResponseException::forCallableMiddleware($this->middleware);
+        }
+
+        return $response;
+    }
+
+    private function decorateHandler(RequestHandlerInterface $handler) : callable
+    {
+        return function ($request, $response) use ($handler) {
+            return $handler->handle($request);
+        };
+    }
+}

--- a/test/Middleware/CallableMiddlewareDecoratorTest.php
+++ b/test/Middleware/CallableMiddlewareDecoratorTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Stratigility\Middleware;
+
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Stratigility\Exception;
+use Zend\Stratigility\Middleware\CallableMiddlewareDecorator;
+
+class CallableMiddlewareDecoratorTest extends TestCase
+{
+    public function testCallableMiddlewareThatDoesNotProduceAResponseRaisesAnException()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $handler = $this->prophesize(RequestHandlerInterface::class)->reveal();
+
+        $middleware = function ($request, $handler) {
+            return 'foo';
+        };
+
+        $decorator = new CallableMiddlewareDecorator($middleware);
+
+        $this->expectException(Exception\MissingResponseException::class);
+        $this->expectExceptionMessage('failed to produce a response');
+        $decorator->process($request, $handler);
+    }
+
+    public function testCallableMiddlewareReturningAResponseSucceedsProcessCall()
+    {
+        $request  = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $handler  = $this->prophesize(RequestHandlerInterface::class)->reveal();
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $middleware = function ($request, $handler) use ($response) {
+            return $response;
+        };
+
+        $decorator = new CallableMiddlewareDecorator($middleware);
+
+        $this->assertSame($response, $decorator->process($request, $handler));
+    }
+}

--- a/test/Middleware/DoublePassMiddlewareDecoratorTest.php
+++ b/test/Middleware/DoublePassMiddlewareDecoratorTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Stratigility\Middleware;
+
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response;
+use Zend\Stratigility\Exception;
+use Zend\Stratigility\Middleware\DoublePassMiddlewareDecorator;
+
+class DoublePassMiddlewareDecoratorTest extends TestCase
+{
+    public function testCallableMiddlewareThatDoesNotProduceAResponseRaisesAnException()
+    {
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $request = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $handler = $this->prophesize(RequestHandlerInterface::class)->reveal();
+
+        $middleware = function ($request, $response, $next) {
+            return 'foo';
+        };
+
+        $decorator = new DoublePassMiddlewareDecorator($middleware, $response);
+
+        $this->expectException(Exception\MissingResponseException::class);
+        $this->expectExceptionMessage('failed to produce a response');
+        $decorator->process($request, $handler);
+    }
+
+    public function testCallableMiddlewareReturningAResponseSucceedsProcessCall()
+    {
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $request  = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $handler  = $this->prophesize(RequestHandlerInterface::class)->reveal();
+
+        $middleware = function ($request, $response, $next) {
+            return $response;
+        };
+
+        $decorator = new DoublePassMiddlewareDecorator($middleware, $response);
+
+        $this->assertSame($response, $decorator->process($request, $handler));
+    }
+
+    public function testCallableMiddlewareCanDelegateViaHandler()
+    {
+        $response = $this->prophesize(ResponseInterface::class);
+        $request  = $this->prophesize(ServerRequestInterface::class);
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler
+            ->handle(Argument::that([$request, 'reveal']))
+            ->will([$response, 'reveal']);
+
+        $middleware = function ($request, $response, $next) {
+            return $next($request, $response);
+        };
+
+        $decorator = new DoublePassMiddlewareDecorator($middleware, $response->reveal());
+
+        $this->assertSame(
+            $response->reveal(),
+            $decorator->process($request->reveal(), $handler->reveal())
+        );
+    }
+
+    public function testDecoratorCreatesAResponsePrototypeIfNoneIsProvided()
+    {
+        $request  = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $handler  = $this->prophesize(RequestHandlerInterface::class)->reveal();
+
+        $middleware = function ($request, $response, $next) {
+            return $response;
+        };
+
+        $decorator = new DoublePassMiddlewareDecorator($middleware);
+
+        $response = $decorator->process($request, $handler);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
+    }
+}


### PR DESCRIPTION
This patch provides two classes, `CallableMiddlewareDecorator` and `DoublePassMiddlewareDecorator`. The former replaces the previous `CallableInteropMiddlewareWrapper`, and the latter is the new version of `CallableMiddlewareWrapper` from the v2 series.

`CallableMiddlewareDecorator` accepts a callable that is expected to conform to the PSR-15 signature basics (accepts a request and handler, and returns a response), but does no verifications on the signature. If no response is returned by the callable, it raises an exception.

`DoublePassMiddlewareDecorator` accepts a callable that follows the double-pass signature (`function ($request, $response, $next)`), but does no verifications on the signature. If no response is returned by the callable, it raises an exception.