### PR TITLE
Updated branch aliases to reference 3.0.0 dev branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,9 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "2.1.0-dev",
-      "dev-develop": "2.2.0-dev"
+      "dev-master": "2.1.x-dev",
+      "dev-develop": "2.2.x-dev",
+      "dev-release-3.0.0": "3.0.x-dev"
     }
   },
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d06efb434935f2b83caf9691f7abcb2b",
+    "content-hash": "7a6e4e85ad33f59c95062ae46a20070c",
     "packages": [
         {
             "name": "http-interop/http-middleware",
@@ -56,6 +56,7 @@
                 "request",
                 "response"
             ],
+            "abandoned": "http-interop/http-server-middleware",
             "time": "2017-01-14T15:23:42+00:00"
         },
         {


### PR DESCRIPTION
Updates all branch aliases to use the documented `M.m.x-dev` format (vs `M.m-dev`). Also added the following map:

```json
"dev-release-3.0.0": "3.0.x-dev"
```

to allow users to develop against that branch.