### PR TITLE
NotFoundHandler is not invokable

### DIFF
--- a/docs/book/migration.md
+++ b/docs/book/migration.md
@@ -150,6 +150,9 @@ All of these classes now implement the PSR-15 `MiddlewareInterface`.
 - `Middleware\ErrorHandler::__invoke()`: this class is no longer invokable.
   Use the `process` method instead.
 
+- `Middleware\NotFoundHandler::__invoke()`: this class is no longer invokable.
+  Use the `process` method instead.
+
 - `Next::__invoke()`: this class is no longer invokable. Use the method `handle`
   instead.
 

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -31,20 +31,6 @@ class NotFoundHandler implements MiddlewareInterface
     }
 
     /**
-     * Proxy to process()
-     *
-     * Proxies to process, after first wrapping the `$next` argument using the
-     * CallableDelegateDecorator.
-     */
-    public function __invoke(
-        ServerRequestInterface $request,
-        ResponseInterface $response,
-        callable $next
-    ) : ResponseInterface {
-        return $this->process($request, new CallableDelegateDecorator($next, $response));
-    }
-
-    /**
      * Creates and returns a 404 response.
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface


### PR DESCRIPTION
Method `process` should be used instead.