### PR TITLE
Deprecations and backports for 2.2.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,6 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
-  allow_failures:
-    - php: 7.2
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' && "$(php --version | grep xdebug -ci)" -ge 1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 env:
   global:
     - COMPOSER_ARGS="--no-interaction --no-plugins"
-    - COVERAGE_DEPS="satooshi/php-coveralls"
+    - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
   include:
@@ -72,7 +72,7 @@ script:
   - if [[ $CS_CHECK == 'true' ]]; then composer license-check ; fi
 
 after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer upload-coverage ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry php vendor/bin/php-coveralls -v  ; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
         - DEPS=lowest
     - php: 5.6
       env:
-        - LEGACY_DEPS="phpunit/phpunit"
+        - LEGACY_DEPS="phpunit/phpunit malukenho/docheader"
         - DEPS=locked
     - php: 5.6
       env:
@@ -29,7 +29,7 @@ matrix:
     - php: 7
       env:
         - DEPS=locked
-        - LEGACY_DEPS="doctrine/instantiator"
+        - LEGACY_DEPS="doctrine/instantiator malukenho/docheader"
         - CS_CHECK=true
         - TEST_COVERAGE=true
     - php: 7

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   "require": {
     "php": "^5.6 || ^7.0",
     "psr/http-message": "^1.0",
-    "webimpress/http-middleware-compatibility": "^0.1.3",
+    "webimpress/http-middleware-compatibility": "^0.1.4",
     "zendframework/zend-escaper": "^2.3"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,11 @@
     "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Stratigility; e.g., zendframework/zend-diactoros"
   },
   "autoload": {
+    "files": [
+      "src/functions/double-pass-middleware.php",
+      "src/functions/middleware.php",
+      "src/functions/path.php"
+    ],
     "psr-4": {
       "Zend\\Stratigility\\": "src/"
     }

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,6 @@
     "cs-fix": "phpcbf",
     "license-check": "docheader check src/ test/",
     "test": "phpunit --colors=always",
-    "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
-    "upload-coverage": "coveralls -v"
+    "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a6e4e85ad33f59c95062ae46a20070c",
+    "content-hash": "303e45900c88a8f7f0866b9ba849ea70",
     "packages": [
         {
             "name": "http-interop/http-middleware",
-            "version": "0.4.1",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9"
+                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/9a801fe60e70d5d608b61d56b2dcde29516c81b9",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9",
+                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/b49e1f9f6c584e704317b563302e566b8ce11858",
+                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858",
                 "shasum": ""
             },
             "require": {
@@ -32,7 +32,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Interop\\Http\\ServerMiddleware\\": "src/"
+                    "Interop\\Http\\Server\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -47,17 +47,16 @@
             ],
             "description": "Common interface for HTTP server-side middleware",
             "keywords": [
-                "factory",
                 "http",
                 "middleware",
                 "psr",
-                "psr-17",
+                "psr-15",
                 "psr-7",
                 "request",
                 "response"
             ],
             "abandoned": "http-interop/http-server-middleware",
-            "time": "2017-01-14T15:23:42+00:00"
+            "time": "2017-09-18T15:27:03+00:00"
         },
         {
             "name": "psr/http-message",
@@ -111,16 +110,16 @@
         },
         {
             "name": "webimpress/composer-extra-dependency",
-            "version": "0.2.0",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/composer-extra-dependency.git",
-                "reference": "97c241b2c80628a2cd1002cece3fc54c419b1776"
+                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/97c241b2c80628a2cd1002cece3fc54c419b1776",
-                "reference": "97c241b2c80628a2cd1002cece3fc54c419b1776",
+                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/31fa56391d30f03b1180c87610cbe22254780ad9",
+                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9",
                 "shasum": ""
             },
             "require": {
@@ -153,29 +152,29 @@
                 "dependency",
                 "webimpress"
             ],
-            "time": "2017-10-11T22:05:48+00:00"
+            "time": "2017-10-17T17:15:14+00:00"
         },
         {
             "name": "webimpress/http-middleware-compatibility",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/http-middleware-compatibility.git",
-                "reference": "5839f5abf54346eafa6617434bd5f618c0cc7adb"
+                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/5839f5abf54346eafa6617434bd5f618c0cc7adb",
-                "reference": "5839f5abf54346eafa6617434bd5f618c0cc7adb",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
+                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
                 "shasum": ""
             },
             "require": {
                 "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
                 "php": "^5.6 || ^7.0",
-                "webimpress/composer-extra-dependency": "^0.2"
+                "webimpress/composer-extra-dependency": "^0.2.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7.22 || ^6.3.1"
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3"
             },
             "type": "library",
             "extra": {
@@ -199,7 +198,7 @@
                 "psr-15",
                 "webimpress"
             ],
-            "time": "2017-10-11T22:13:48+00:00"
+            "time": "2017-10-17T17:31:10+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -303,25 +302,26 @@
         },
         {
             "name": "malukenho/docheader",
-            "version": "0.1.5",
+            "version": "0.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/malukenho/docheader.git",
-                "reference": "f35ada934d1de3f5ba09970a6541009a41347658"
+                "reference": "3eb59f0621125c0dc40775f1bcc3206c37993703"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/malukenho/docheader/zipball/f35ada934d1de3f5ba09970a6541009a41347658",
-                "reference": "f35ada934d1de3f5ba09970a6541009a41347658",
+                "url": "https://api.github.com/repos/malukenho/docheader/zipball/3eb59f0621125c0dc40775f1bcc3206c37993703",
+                "reference": "3eb59f0621125c0dc40775f1bcc3206c37993703",
                 "shasum": ""
             },
             "require": {
                 "php": "~5.5|^7.0",
-                "symfony/console": "~2.0|^3.0",
-                "symfony/finder": "~2.0|^3.0"
+                "symfony/console": "~2.0 || ^3.0 || ^4.0",
+                "symfony/finder": "~2.0 || ^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.7"
+                "phpunit/phpunit": "^4.7",
+                "squizlabs/php_codesniffer": "^2.8"
             },
             "bin": [
                 "bin/docheader"
@@ -349,41 +349,44 @@
                 "code standard",
                 "license"
             ],
-            "time": "2016-11-17T16:46:05+00:00"
+            "time": "2017-12-18T09:16:11+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
-                }
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -391,7 +394,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-04-12T18:52:22+00:00"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -551,29 +554,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.1.1",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -592,7 +601,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-30T18:51:59+00:00"
+            "time": "2017-11-27T17:38:31+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -643,16 +652,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.2",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
@@ -664,7 +673,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
@@ -702,20 +711,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-09-04T11:05:03+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b"
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8ed1902a57849e117b5651fc1a5c48110946c06b",
-                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
                 "shasum": ""
             },
             "require": {
@@ -724,14 +733,13 @@
                 "php": "^7.0",
                 "phpunit/php-file-iterator": "^1.4.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
+                "phpunit/php-token-stream": "^2.0.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.5",
                 "phpunit/phpunit": "^6.0"
             },
             "suggest": {
@@ -740,7 +748,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.2.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -755,7 +763,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -766,20 +774,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-08-03T12:40:43+00:00"
+            "time": "2017-12-06T09:29:45+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -813,7 +821,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -907,16 +915,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
@@ -952,20 +960,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-08-20T05:47:52+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.4.1",
+            "version": "6.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b770d8ba7e60295ee91d69d5a5e01ae833cac220"
+                "reference": "83d27937a310f2984fd575686138597147bdc7df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b770d8ba7e60295ee91d69d5a5e01ae833cac220",
-                "reference": "b770d8ba7e60295ee91d69d5a5e01ae833cac220",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/83d27937a310f2984fd575686138597147bdc7df",
+                "reference": "83d27937a310f2984fd575686138597147bdc7df",
                 "shasum": ""
             },
             "require": {
@@ -979,12 +987,12 @@
                 "phar-io/version": "^1.0",
                 "php": "^7.0",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.2.2",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^4.0.3",
-                "sebastian/comparator": "^2.0.2",
+                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "sebastian/comparator": "^2.1",
                 "sebastian/diff": "^2.0",
                 "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
@@ -1010,7 +1018,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.4.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -1036,33 +1044,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-10-07T17:53:53+00:00"
+            "time": "2017-12-17T06:31:19+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "4.0.4",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0"
+                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/2f789b59ab89669015ad984afa350c4ec577ade0",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.5",
                 "php": "^7.0",
                 "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.0"
+                "sebastian/exporter": "^3.1"
             },
             "conflict": {
                 "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.5"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1070,7 +1078,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -1085,7 +1093,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1095,54 +1103,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-08-03T14:08:16+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2018-01-06T05:45:45+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1191,30 +1152,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.0.2",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a"
+                "reference": "b11c729f95109b56a0fe9650c6a63a0fcd8c439f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
-                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/b11c729f95109b56a0fe9650c6a63a0fcd8c439f",
+                "reference": "b11c729f95109b56a0fe9650c6a63a0fcd8c439f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
                 "sebastian/diff": "^2.0",
-                "sebastian/exporter": "^3.0"
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -1245,13 +1206,13 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-08-03T07:14:59+00:00"
+            "time": "2017-12-22T14:50:35+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1705,16 +1666,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.7.1",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f"
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9b324f3a1132459a7274a0ace2e1b766ba80930f",
-                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
                 "shasum": ""
             },
             "require": {
@@ -1779,43 +1740,48 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-11-30T04:02:31+00:00"
+            "time": "2017-05-22T02:43:20+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.2.2",
+            "version": "v4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "4f9e449e76996adf310498a8ca955c6deebe29dd"
+                "reference": "fe0e69d7162cba0885791cf7eea5f0d7bc0f897e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/4f9e449e76996adf310498a8ca955c6deebe29dd",
-                "reference": "4f9e449e76996adf310498a8ca955c6deebe29dd",
+                "url": "https://api.github.com/repos/symfony/console/zipball/fe0e69d7162cba0885791cf7eea5f0d7bc0f897e",
+                "reference": "fe0e69d7162cba0885791cf7eea5f0d7bc0f897e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
-                "symfony/debug": "~2.8|~3.0",
+                "php": "^7.1.3",
                 "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/filesystem": "~2.8|~3.0",
-                "symfony/process": "~2.8|~3.0"
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
-                "symfony/filesystem": "",
+                "symfony/lock": "",
                 "symfony/process": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1842,86 +1808,29 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-08T20:47:33+00:00"
-        },
-        {
-            "name": "symfony/debug",
-            "version": "v3.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "810ba5c1c5352a4ddb15d4719e8936751dff0b05"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/810ba5c1c5352a4ddb15d4719e8936751dff0b05",
-                "reference": "810ba5c1c5352a4ddb15d4719e8936751dff0b05",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9",
-                "psr/log": "~1.0"
-            },
-            "conflict": {
-                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
-            },
-            "require-dev": {
-                "symfony/class-loader": "~2.8|~3.0",
-                "symfony/http-kernel": "~2.8|~3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Debug\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Debug Component",
-            "homepage": "https://symfony.com",
-            "time": "2017-01-02T20:32:22+00:00"
+            "time": "2018-01-03T07:38:00+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.2.2",
+            "version": "v4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8c71141cae8e2957946b403cc71a67213c0380d6"
+                "reference": "8b08180f2b7ccb41062366b9ad91fbc4f1af8601"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8c71141cae8e2957946b403cc71a67213c0380d6",
-                "reference": "8c71141cae8e2957946b403cc71a67213c0380d6",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8b08180f2b7ccb41062366b9ad91fbc4f1af8601",
+                "reference": "8b08180f2b7ccb41062366b9ad91fbc4f1af8601",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1948,20 +1857,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-02T20:32:22+00:00"
+            "time": "2018-01-03T07:38:00+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.3.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
-                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
                 "shasum": ""
             },
             "require": {
@@ -1973,7 +1882,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -2007,7 +1916,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2130,34 +2039,36 @@
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.3.10",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "83e8d98b9915de76c659ce27d683c02a0f99fa90"
+                "reference": "ed6ce7e2105c400ca10277643a8327957c0384b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/83e8d98b9915de76c659ce27d683c02a0f99fa90",
-                "reference": "83e8d98b9915de76c659ce27d683c02a0f99fa90",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/ed6ce7e2105c400ca10277643a8327957c0384b7",
+                "reference": "ed6ce7e2105c400ca10277643a8327957c0384b7",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.4 || ^7.0",
-                "psr/http-message": "~1.0"
+                "php": "^5.6 || ^7.0",
+                "psr/http-message": "^1.0"
             },
             "provide": {
-                "psr/http-message-implementation": "~1.0.0"
+                "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6 || ^5.5",
-                "zendframework/zend-coding-standard": "~1.0.0"
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "phpunit/phpunit": "^5.7.16 || ^6.0.8",
+                "zendframework/zend-coding-standard": "~1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev",
-                    "dev-develop": "1.4-dev"
+                    "dev-master": "1.7.x-dev",
+                    "dev-develop": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -2176,7 +2087,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-01-23T04:53:24+00:00"
+            "time": "2018-01-04T18:21:48+00:00"
         }
     ],
     "aliases": [],

--- a/docs/book/api.md
+++ b/docs/book/api.md
@@ -681,3 +681,67 @@ class TimestampMiddleware implements ServerMiddlewareInterface
     }
 }
 ```
+
+## Utility Functions
+
+Stratigility provides the following utility functions.
+
+### path
+
+````
+function Zend\Stratigility\path(
+    string $pathPrefix,
+    Interop\Http\Server\MiddlewareInterface $middleware
+) : Zend\Stratigility\Middleware\PathMiddlewareDecorator
+```
+
+`path()` provides a convenient way to perform path segregation when piping your
+middleware.
+
+```php
+$pipeline->pipe(path('/foo', $middleware));
+```
+
+### middleware
+
+````
+function Zend\Stratigility\middleware(
+    callable $middleware
+) : Zend\Stratigility\Middleware\CallableMiddlewareDecorator
+```
+
+`middleware()` provides a convenient way to decorate callable middleware that
+implements the PSR-15 middleware signature when piping it to your application.
+
+```php
+$pipeline->pipe(middleware(function ($request, $handler) {
+  // ...
+});
+```
+
+### doublePassMiddleware
+
+````
+function Zend\Stratigility\doublePassMiddleware(
+    callable $middleware,
+    Psr\Http\Message\ResponseInterface $responsePrototype = null
+) : Zend\Stratigility\Middleware\DoublePassMiddlewareDecorator
+```
+
+`doublePassiddleware()` provides a convenient way to decorate middleware that
+implements the double pass middleware signature when piping it to your application.
+
+```php
+$pipeline->pipe(doublePassMiddleware(function ($request, $response, $next) {
+  // ...
+});
+```
+
+If you are not using zend-diactoros as a PSR-7 implementation, you will need to
+pass a response prototype as well:
+
+```php
+$pipeline->pipe(doublePassMiddleware(function ($request, $response, $next) {
+  // ...
+}, $response);
+```

--- a/docs/book/api.md
+++ b/docs/book/api.md
@@ -607,8 +607,8 @@ This class is forwards compatible with version 3.
 - Deprecated since 2.2.0
 
 This is a middleware decorator for PHP callables that have a signature
-compatible with http-interop/http-middleware version 0.4.1. Please see the
-[Creating Middleware standards-based callable middleware
+compatible with http-interop/http-middleware version 0.4.1 or 0.5.0. Please see
+the [Creating Middleware standards-based callable middleware
 documentation](creating-middleware.md#callable-standards-signature-middleware).
 
 ### CallableMiddlewareWrapper
@@ -691,7 +691,7 @@ Stratigility provides the following utility functions.
 ````
 function Zend\Stratigility\path(
     string $pathPrefix,
-    Interop\Http\Server\MiddlewareInterface $middleware
+    Interop\Http\Server\MiddlewareInterface|Interop\Http\ServerMiddleware\MiddlewareInterface $middleware
 ) : Zend\Stratigility\Middleware\PathMiddlewareDecorator
 ```
 

--- a/docs/book/api.md
+++ b/docs/book/api.md
@@ -75,9 +75,29 @@ the value `/`; this is an indication that the `$middleware` should be invoked
 for any path. If `$path` is provided, the `$middleware` will only be executed
 for that path and any subpaths.
 
+> ### Use the PathMiddlewareDecorator to segregate middleware by path
+>
+> - Since 2.2.0
+>
+> Starting in 2.2.0, we have deprecated the 2-argument form of `pipe()`, as
+> version 3 will use only one argument, typehinted against the PSR-15
+> `MiddlewareInterface`. Version 2.2.0 introduces a decorator for accomplishing
+> the same functionality:
+>
+> ```php
+> use Zend\Stratigility\Middleware\PathMiddlewareDecorator;
+>
+> $pipeline->pipe(new PathMiddlewareDecorator($path, $middleware));
+> ```
+>
+> If you continue to use the 2-argument form of `pipe()`, internally it will
+> decorate your middleware regardless &mdash; and also trigger a deprecation
+> error. To avoid the deprecation error, update your code today!
+
 > ### Request path changes when path matched
 >
-> When you pipe middleware using a path (other than '' or '/'), the middleware
+> When you pipe middleware using a path (other than '' or '/') or use the
+> `PathMiddlewareDecorator` (as outlined in the previous note), the middleware
 > is dispatched with a request that strips the matched segment(s) from the start
 > of the path.
 >
@@ -93,6 +113,9 @@ The `MiddlewarePipe` is itself middleware, and can be executed in stacks that
 expect the `__invoke()` signature (via the `__invoke()` signature), or stacks
 expecting http-interop middleware signatures (via the `process()` method).
 
+> ### Invocation is deprecated
+>
+> Starting in version 2.2.0, invocation via `__invoke()` is deprecated.
 
 When using `__invoke()`, the callable `$out` argument should either implement
 delegator/request handler interface from `http-interop/http-middleware`
@@ -146,12 +169,23 @@ $pipeline = new MiddlewarePipe();
 $pipeline->setResponsePrototype(new Response());
 ```
 
+> ### Response prototype deprecated
+>
+> Starting in version 2.2.0, the `setResponsePrototype()` method is deprecated.
+> This is because version 3 will no longer accept non-PSR-15 middleware.
+> Callable middleware will need to be decorated using one of
+> `CallableMiddlewareDecorator` (for callable middleware implementing the PSR-15
+> signature) or `DoublePassMiddlewareDecorator` (for callable middleware expecting
+> a response and `$next` argument). The latter decorator expects a response
+> prototype as its second argument.
+
 ## Next
 
 `Zend\Stratigility\Next` is primarily an implementation detail of middleware,
 and exists to allow delegating to middleware registered later in the stack. It
 is implemented both as a functor and as an http-interop/http-middleware
-`DelegateInterface`.
+`DelegateInterface` and http-interop/http-server-handler
+`RequestHandlerInterface`.
 
 ### Functor invocation
 
@@ -199,6 +233,19 @@ when calling it in your application, or return a response yourself.
 - Since 1.3.0.
 
 When invoked as a `DelegateInterface`, the `process()` method will be invoked, and
+passed a `ServerRequestInterface` instance *only*. If you need to return a response,
+you will need to:
+
+- Compose a response prototype in the middleware to use to build a response, or a
+  canned response to return, OR
+- Create and return a concrete response type, OR
+- Operate on a response returned by invoking the delegate.
+
+### RequestHandler invocation
+
+- Since 2.1.0
+
+When invoked as a `RequestHandlerInterface`, the `handle()` method will be invoked, and
 passed a `ServerRequestInterface` instance *only*. If you need to return a response,
 you will need to:
 
@@ -452,57 +499,144 @@ for more details.
 
 ## Middleware Decorators
 
-Starting in version 1.3.0, we offer the ability to work with
-http-interop/http-middleware. Internally, if a response prototype is composed in
-the `MiddlewarePipe`, callable middleware piped to the `MiddlewarePipe` will be
-wrapped in one of these decorators.
+The following decorator classes are each in the `Zend\Stratigility\Middleware`
+namespace, and fulfill the installed `MiddlewareInterface` based on the
+http-interop/http-middleware version installed in your application.
 
-Two versions exist:
-
-- `Zend\Stratigility\Middleware\CallableMiddlewareWrapper` will wrap a callable
-  using the legacy interface; as such, it also requires a response instance:
-
-  ```php
-  $middleware = new CallableMiddlewareWrapper($middleware, $response);
-  ```
-
-- `Zend\Stratigility\Middleware\CallableMiddlewareWrapper` will wrap a callable
-  that defines exactly two arguments, with the second type-hinting on the
-  http-interop/http-middleware `DelegateInterface` (versions &lt; 0.5):
-
-  ```php
-  $middleware = new CallableMiddlewareWrapper(
-      function ($request, DelegateInterface $delegate) {
-          // ... 
-      }
-  );
-  ```
-
-  or `RequestHandlerInterface` (versions 0.5.0 or greater):
-
-  ```php
-  $middleware = new CallableMiddlewareWrapper(
-      function ($request, RequestHandlerInterface $handler) {
-          // ...
-      }
-  );
-  ```
-
-You can manually decorate callable middleware using these decorators, or simply
+You can manually decorate callable middleware using these decorators, or instead
 let `MiddlewarePipe` do the work for you. To let `MiddlewarePipe` handle this,
 however, you _must_ compose a response prototype prior to piping middleware
-using the legacy middleware signature.
+using the double pass middleware signature.
+
+### PathMiddlewareDecorator
+
+- Since 2.2.0
+
+The `PathMiddlewareDecorator` can be used to segregate middleware by request URI
+path prefix. This can be done for several purposes:
+
+- To execute such middleware only if a given path prefix is matched; e.g.,
+  if you have middleware you want to run for every URI that matches
+  `/api` (e.g., to run rate limiting middleware).
+- To re-use an existing middleware that has its own internal routing under a
+  specific path; e.g., a "shopping cart" middleware pipeline/application that
+  you wish to run under the path `/store` on one site, but under `/shop` on
+  another, while otherwise retaining the same functionality.
+
+The `PathMiddlewareDecorator` constructor accepts two arguments: a string path
+prefix to match, and an http-interop `MiddlewareInterface` instance:
+
+```php
+$middleware = new PathMiddlewareDecorator('/api', $apiMiddleware);
+```
+
+When the path prefix is matched in the current request, the decorator will
+strip the path prefix from the request passed to the composed middleware.
+
+If the middleware calls on the handler, the decorator will replace the request
+URI's path with the path from the original request before invoking the handler.
+
+### CallableMiddlewareDecorator
+
+- Since 2.2.0
+
+This class will decorate any PHP callable middleware that follows the signatures
+of either of the `MiddlewareInterface` from either the 0.4.1 or 0.5.0 version of
+the http-interop/http-middleware package.
+
+Typically, this looks like:
+
+```php
+function ($request, $handler) : Psr\Http\Message\ResponseInterface
+```
+
+where `$handler` will either be of the type
+`Interop\Http\ServerMiddleware\DelegateInterface` or
+`Interop\Http\Server\RequestHandlerInterface`, depending on the http-interop
+version used in your application.
+
+The decorator receives the PHP callable as its sole constructor argument, and is
+then suitable for piping into the application:
+
+```php
+use Zend\Stratigility\Middleware\CallableMiddlewareDecorator;
+
+$pipeine->pipe(new CallableMiddlewareDecorator(function ($request, $handler) {
+    // ...
+}));
+```
+
+This class is forwards compatible with version 3.
+
+### DoublePassMiddlewareDecorator
+
+- Since 2.2.0
+
+This class will decorate any PHP callable middleware that follows the "[double
+pass signature](creating-middleware.md#double-pass-middleware)double-pass"  as a
+`MiddlewareInterface` implementation of either the 0.4.1 or 0.5.0 version of
+http-interop.
+
+Typically, this looks like:
+
+```php
+function ($request, $response, $next) : Psr\Http\Message\ResponseInterface
+```
+
+where `$next` is a callable for invoking the next middleware layer, and expects
+
+The decorator receives the PHP callable and a PSR-7 `ResponseInterface` instance
+as its arguments, and is then suitable for piping into the application:
+
+```php
+use Zend\Stratigility\Middleware\DoublePassMiddlewareDecorator;
+
+$pipeine->pipe(new DoublePassMiddlewareDecorator(
+    function ($request, $response, $next) {
+        // ...
+    },
+    $responsePrototype
+));
+```
+
+This class is forwards compatible with version 3.
+
+### CallableInteropMiddlewareWrapper
+
+- Since 1.3.0
+- Deprecated since 2.2.0
+
+This is a middleware decorator for PHP callables that have a signature
+compatible with http-interop/http-middleware version 0.4.1. Please see the
+[Creating Middleware standards-based callable middleware
+documentation](creating-middleware.md#callable-standards-signature-middleware).
+
+### CallableMiddlewareWrapper
+
+- Since 1.3.0
+- Deprecated since 2.2.0
+
+This is a middleware decorator for PHP callables that follow the [double pass
+signature](creating-middleware.md#double-pass-middleware). If you plan use
+double pass middleware in version 2.2.0 or later, we recommend using the
+[`DoublePassMiddlewareDecorator`](#doublepassmiddlewaredecorator) instead.
 
 ## Delegates
 
+- Since 2.0.0
+- Deprecated since 2.2.0
+
 In addition to `Zend\Stratigility\Next`, Stratigility provides another
-http-interop/http-middleware `DelegateInterface` implementation,
-`Zend\Stratigility\Delegate\CallableDelegateDecorator`.
+delegate/request handler implementation via 
+`Zend\Stratigility\Delegate\CallableDelegateDecorator`. This class will work
+with either http-interop/http-middleware 0.4.1 or 0.5.0, implementing the
+`DelegateInterface` in the case of the former, or the `RequestHandlerInterface`
+in the case of the latter.
 
 This class can be used to wrap a callable `$next` instance for use in passing to
-an http-interop/http-middleware middleware interface `process()`/`handle()`
-method as a delegate; the primary use case is adapting functor middleware to
-work as http-interop middleware.
+an http-interop/http-middleware middleware interface `process()` method as a
+delegate; the primary use case is adapting functor middleware to work as
+http-interop middleware.
 
 As an example:
 

--- a/docs/book/creating-middleware.md
+++ b/docs/book/creating-middleware.md
@@ -1,89 +1,313 @@
 # Creating Middleware
 
-To create middleware, write a callable capable of receiving minimally PSR-7
-ServerRequest and Response objects, and a callback to call the next middleware
-in the chain. In your middleware, you can handle as much or as little of the
-request as you want, including delegating to other middleware. By accepting the
-third argument, `$next`, it can allow further processing via invoking that
-argument, or return handling to the parent middleware by returning a response.
+Stratigility provides several ways to write middleware:
 
-As an example, consider the following middleware which will use an external
-router to map the incoming request path to a handler; if unable to map the
-request, it returns processing to the next middleware.
+- By implementing a standard interface.
+- By writing a PHP callable that uses the same signature as the standard
+  interface.
+- By writing a PHP callable accepting standard PSR-7 messages.
+
+This document catalogs each of these, and includes pros and cons for each
+pattern.
+
+In all cases, middleware can do each (or all!) of the following:
+
+- Examine a request, and return a response if certain requirements
+  are (or are not!) met.
+- Delegate handling (and thus response generation) to the next layer.
+- Manipulate the response returned by a lower layer, and return the modified
+  version.
+
+With each of the types below, we will demonstrate the same example: using an
+external router instance to attempt to route a request and delegate to the
+middleware matched.
+
+## MiddlewareInterface
+
+- Since 1.3.0
+
+The [PHP-FIG standards body](http://www.php-fig.org) identifies and ratifies
+standards for community use. One of these,
+[PSR-7](http://www.php-fig.org/psr/psr-7/) is used by Stratigility to provide
+standard HTTP message interfaces.
+
+Another, the proposed [PSR-15 (HTTP Server Request
+Handlers)](https://github.com/php-fig/fig-standards/tree/4b417c91b89fbedaf3283620ce432b6f51c80cc0/proposed/http-handlers),
+defines interfaces for handling and producing these messages.
+
+The specification has undergone several revisions via its working group, and
+this version of Stratigility supports the following:
+
+- [http-interop/http-middleware v0.4.1](https://github.com/http-interop/http-middleware/releases/tag/0.4.1)
+- [http-interop/http-middleware v0.5.0](https://github.com/http-interop/http-middleware/releases/tag/0.5.0)
+
+The two use different namespaces, and the intermediary interface is named
+differently between the two (and defines a different method).
+
+If you are new to Stratigility, we suggest using the latest version of the spec,
+as it is closest to how the final PSR-15 specificaion defines the interfaces,
+and will only require changing the namespace from which you import the
+interfaces later. If you are upgrading, however, choose the 0.4.1 version to
+retain existing compatibility.
+
+When writing middleware targeting http-middleware 0.4.1, define your middleware
+as follows:
 
 ```php
-function ($req, $res, $next) use ($router) {
-    $path = $req->getUri()->getPath();
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
-    // Route the path
-    $route = $router->route($path);
-    if (! $route) {
-        return $next($req, $res);
+class MyMiddleware implements MiddlewareInterface
+{
+    private $router;
+
+    public function __construct($router)
+    {
+        $this->router = $router;
     }
 
-    $handler = $route->getHandler();
-    return $handler($req, $res, $next);
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        $path = $request->getUri()->getPath();
+
+        // Route the path
+        $route = $this->router->route($path);
+        if (! $route) {
+            return $delegate->process($request);
+        }
+
+        $middleware = $route->getHandler();
+        return $middleware->process($request, $delegate);
+    }
 }
 ```
 
-Middleware written in this way can be any of the following:
+Under http-middleware 0.5.0, the example becomes the following:
 
-- Closures (as shown above)
-- Functions
-- Static class methods
-- PHP array callbacks (e.g., `[ $dispatcher, 'dispatch' ]`, where `$dispatcher` is a class instance)
-- Invokable PHP objects (i.e., instances of classes implementing `__invoke()`)
-- Objects implementing `Zend\Stratigility\MiddlewareInterface`
+```php
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
-In all cases, if you wish to implement typehinting, the signature is:
+class MyMiddleware implements MiddlewareInterface
+{
+    private $router;
+
+    public function __construct($router)
+    {
+        $this->router = $router;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler)
+    {
+        $path = $request->getUri()->getPath();
+
+        // Route the path
+        $route = $this->router->route($path);
+        if (! $route) {
+            return $handler->handle($request);
+        }
+
+        $middleware = $route->getHandler();
+        return $middleware->process($request, $delegate);
+    }
+}
+```
+
+Note that the primary difference is the change from `DelegateInterface` to
+`RequestHandlerInterface`; also note that the method each defines is different
+(`process` vs `handle`).
+
+## Callable standards-signature middleware
+
+- Since 1.3.0: `CallableInteropMiddlewareWrapper`
+- Since 2.2.0: `CallableMiddlewareDecorator`
+- Deprecated since 2.2.0: `CallableInteropMiddlewareWrapper`
+
+You may also write PHP callables that fulfill the http-middleware interface
+signatures as defined in the previous section.
+
+If your middleware satisfies the http-interop 0.4.1 signature (which, in this
+case, means that it expects a `DelegateInterface`, and will call its `process()`
+method), use `CallableInteropMiddlewareWrapper`:
+
+```php
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper;
+
+$pipeline->pipe(new CallableInteropMiddlewareWrapper(
+    function ($request, $delegate) use ($router) {
+        $path = $request->getUri()->getPath();
+
+        // Route the path
+        $route = $router->route($path);
+        if (! $route) {
+            return $delegate->process($request);
+        }
+
+        $middleware = $route->getHandler();
+        return $middleware->process($request, $delegate);
+    }
+))
+```
+
+Starting in 2.0, when you pipe such middleware directly to `MiddlewarePipe`, it
+internally decorates it for you using this class.
+
+> ### CallableInteropMiddlewareWrapper deprecated
+>
+> The `CallableInteropMiddlewareWrapper` is deprecated starting in version
+> 2.2.0, and will be removed entirely for version 3.0.0. We recommend updating
+> your code to use http-middleware 0.5.0 and the `CallableMiddlewareDecorator`
+> to make your code future-proof.
+
+If your middleware satisfies the http-interop 0.5.0 signature (which, in this
+case, means that it expects a `RequestHandlerInterface`, and will call its
+`handle()` method), use `CallableMiddlewareDecorator`:
+
+```php
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Zend\Stratigility\Middleware\CallableMiddlewareDecorator;
+
+$pipeline->pipe(new CallableMiddlewareDecorator(
+    function ($request, $handler) use ($router) {
+        $path = $request->getUri()->getPath();
+
+        // Route the path
+        $route = $router->route($path);
+        if (! $route) {
+            return $handler->handle($request);
+        }
+
+        $middleware = $route->getHandler();
+        return $middleware->process($request, $delegate);
+    }
+))
+```
+
+Starting in 2.2.0, when you pipe such middleware directly to `MiddlewarePipe`,
+it internally decorates it for you using this class.
+
+## Double Pass Middleware
+
+- Since 1.0.0: piping double-pass middleware directly
+- Since 1.3.0: `CallableMiddlewareWrapper` since 1.3.0; deprecated in 2.2.0
+- Since 2.2.0: `DoublePassMiddlewareDecorator`
+- Deprecated since 2.2.0: piping double-pass middleware directly
+- Deprecated since 2.2.0: `CallableMiddlewareWrapper`
+
+The last style of middleware is called "double pass" middleware.
+
+The signature of such middleware is as follows:
 
 ```php
 function (
-    Psr\Http\Message\ServerRequestInterface $request,
-    Psr\Http\Message\ResponseInterface $response,
+    ServerRequestInterface $request,
+    ResponseInterface $response,
     callable $next
-) : Psr\Http\Message\ResponseInterface
+)
 ```
 
-## http-interop middleware
-
-You can also write middleware which implements interfaces from
-`http-interop/http-middleware`. Stratigility 2.1 supports all versions of
-http-interop middleware that are supported by the package
-[webimpress/http-middleware-compatibility](https://github.com/webimpress/http-middleware-compatibility).
-
-As an example of http-interop middleware:
+where the callable is expected to return a PSR-7 `ResponseInterface`, and where
+`$next` has the following signature:
 
 ```php
-// http-interop/http-middleware 0.2:
-use Interop\Http\Middleware\DelegateInterface;
-use Interop\Http\Middleware\ServerMiddlewareInterface;
-
-// http-interop/http-middleware 0.4.1:
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
-
-// http-interop/http-middleware 0.5.0:
-use Interop\Http\Server\MiddlewareInterface as ServerMiddlewareInterface;
-use Interop\Http\Server\RequestHandlerInterface as DelegateInterface;
-
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-
-class MyMiddleware implements ServerMiddlewareInterface
-{
-    public function process(
-        ServerRequestInterface $request,
-        DelegateInterface $delegate
-    ) : ResponseInterface {
-        // ... do something and return response
-        // or call delegate:
-
-        // http-interop/http-middleware < 0.5:
-        // return $delegate->delegate($request);
-
-        // http-interop/http-middleware 0.5.0:
-        // return $delegate->handle($request);
-    }
-}
+function (
+    ServerRequestInterface $request,
+    ResponseInterface $response
+)
 ```
+
+and is also expected to return a response.
+
+This latter function is the basis for the name "double pass"; you pass _both_ a
+request _and_ a response to the next layer.
+
+Neither the callable arguments nor the return value need typehints, though we
+recommend them for type safety.
+
+In versions prior to 2.0, you could pipe double-pass middleware directly to the
+pipeline:
+
+```php
+$pipeline->pipe(function ($request, $response, $next) {});
+```
+
+While this usage is still possible in the v2 series, we recommend against using
+it for two reasons:
+
+- Version 3 will no longer support direct piping of such middleware.
+- The signature does not follow the PSR-15 standards, making the middleware
+  non-portable to other PSR-15 middleware dispatcher stacks.
+
+As such, we provide options for you to decorate such middleware.
+
+> ### Do not operate on the response
+>
+> If you are creating double pass middleware, do not use the `$response`
+> argument passed to the middleware as anything other than a prototype
+> from which to build a response to return from the method.
+>
+> If you manipulate the response before passing it to the next layer, the next
+> layer may choose to return a completely different response; in the case of
+> standards-based middleware, it will never even receive the instance!
+>
+> If changes to the response are necessary, operate only on the response
+> _returned_ by the next layer.
+
+### CallableMiddlewareWrapper
+
+- Since 1.3.0
+- Deprecated since 2.2.0
+
+Our first double-pass middleware decorator is
+`Zend\Stratigility\Middleware\CallableMiddlewareWrapper`, which implements the
+http-middleware 0.4.1 `MiddlewareInterface`:
+
+```php
+$pipeline->pipe(new CallableMiddlewareWrapper(
+    function ($request, $response, $next) {},
+    $responsePrototype
+));
+```
+
+The `$responsePrototype` argument is required, as without it, there is no
+response instance to pipe to the decorated middleware.
+
+Starting in 2.0, if you pipe such middleware directly to `MiddlewarePipe`, it
+internally decorates it for you, as long as the pipeline also composes a
+response prototype:
+
+```php
+$pipeline->setResponsePrototype(new Response());
+$pipeline->pipe($doublePassMiddleware);
+```
+
+We recommend always decorating the middleware manually. We also recommend
+migrating to the `DoublePassMiddlewareDecorator` to make your code forwards
+compatible with version 3.
+
+### DoublePassMiddlewareDecorator
+
+- Since 2.2.0
+
+`Zend\Stratigility\Middleware\DoublePassMiddlewareDecorator` implements the
+http-middleware 0.5.0 `MiddlewareInterface`, and will be updated in version 3 to
+implement the PSR-15 `MiddlewareInterface`:
+
+```php
+$pipeline->pipe(new CallableMiddlewareWrapper(
+    function ($request, $response, $next) {},
+    $responsePrototype
+));
+```
+
+As with the `CallableMiddlewareWrapper`, the `$responsePrototype` argument is
+required, as without it, there is no response instance to pipe to the decorated
+middleware.
+
+Starting in version 2.2.0, piping double pass middleware directly to
+`MiddlewarePipe` internally decorates it using the
+`DoublePassMiddlewareDecorator` internally, so long as you have also already
+composed a response prototype in the `MiddlewarePipe` instance.

--- a/docs/book/creating-middleware.md
+++ b/docs/book/creating-middleware.md
@@ -159,8 +159,11 @@ internally decorates it for you using this class.
 >
 > The `CallableInteropMiddlewareWrapper` is deprecated starting in version
 > 2.2.0, and will be removed entirely for version 3.0.0. We recommend updating
-> your code to use http-middleware 0.5.0 and the `CallableMiddlewareDecorator`
-> to make your code future-proof.
+> your code to use the `CallableMiddlewareDecorator` to make your code
+> future-proof.
+>
+> If possible, also upgrade to http-interop/http-middleware 0.5.0, and use the
+> `handle()` method of the `$handler` argument. 
 
 If your middleware satisfies the http-interop 0.5.0 signature (which, in this
 case, means that it expects a `RequestHandlerInterface`, and will call its
@@ -262,8 +265,9 @@ As such, we provide options for you to decorate such middleware.
 - Deprecated since 2.2.0
 
 Our first double-pass middleware decorator is
-`Zend\Stratigility\Middleware\CallableMiddlewareWrapper`, which implements the
-http-middleware 0.4.1 `MiddlewareInterface`:
+`Zend\Stratigility\Middleware\CallableMiddlewareWrapper`, which implements
+either the http-middleware 0.4.1 or 0.5.0 `MiddlewareInterface`, depending on
+what is installed:
 
 ```php
 $pipeline->pipe(new CallableMiddlewareWrapper(

--- a/docs/book/install.md
+++ b/docs/book/install.md
@@ -21,7 +21,8 @@ Stratigility has the following dependencies (which are managed by Composer):
   http-interop/http-middleware dependency in your `composer.json`, and you can
   use any version which is currently supported by the polyfill package
   [webimpress/http-middleware-compatibility](https://github.com/webimpress/http-middleware-compatibility);
-  if you are creating a new project, we recommend version 0.5.0.
+  if you are creating a new project, we recommend version 0.5.0 (though current
+  versions of Expressive may only support 0.4.1).
 
 - `zendframework/zend-escaper`, used by the `ErrorHandler` middleware and the
   (legacy) `FinalHandler` implementation for escaping error messages prior to

--- a/docs/book/install.md
+++ b/docs/book/install.md
@@ -20,7 +20,8 @@ Stratigility has the following dependencies (which are managed by Composer):
   0.4.1+. Since Stratigility 2.1 you have to explicitly define an
   http-interop/http-middleware dependency in your `composer.json`, and you can
   use any version which is currently supported by the polyfill package
-  [webimpress/http-middleware-compatibility](https://github.com/webimpress/http-middleware-compatibility).
+  [webimpress/http-middleware-compatibility](https://github.com/webimpress/http-middleware-compatibility);
+  if you are creating a new project, we recommend version 0.5.0.
 
 - `zendframework/zend-escaper`, used by the `ErrorHandler` middleware and the
   (legacy) `FinalHandler` implementation for escaping error messages prior to

--- a/docs/book/middleware.md
+++ b/docs/book/middleware.md
@@ -10,6 +10,8 @@ response or pass delegation on to the next middleware in the queue.
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Server;
 use Zend\Stratigility\MiddlewarePipe;
+use Zend\Stratigility\Middleware\CallableMiddlewareDecorator;
+use Zend\Stratigility\Middleware\PathMiddlewareDecorator;
 use Zend\Stratigility\NoopFinalHandler;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -18,181 +20,62 @@ $app = new MiddlewarePipe();
 $app->setResponsePrototype(new Response());
 
 $server = Server::createServer($app, $_SERVER, $_GET, $_POST, $_COOKIE, $_FILES);
+$response = new Response();
 
 // Landing page
-$app->pipe('/', function ($req, $res, $next) {
-    if (! in_array($req->getUri()->getPath(), ['/', ''], true)) {
-        return $next($req, $res);
+$app->pipe(new CallableMiddlewareDecorator(
+    function ($request, $handler) use ($response) {
+        if (! in_array($req->getUri()->getPath(), ['/', ''], true)) {
+            return $handler->handle($request);
+        }
+        $response->getBody()->write('Hello world!');
+        return $response;
     }
-    $res->getBody()->write('Hello world!');
-    return $res;
-});
+));
 
 // Another page
-$app->pipe('/foo', function ($req, $res, $next) {
-    $res->getBody()->write('FOO!');
-    return $res;
-});
+$app->pipe(new PathMiddlewareDecorator(
+    '/foo', 
+    new CallableMiddlewareDecorator(function ($request, $handler) use ($response) {
+        $response->getBody()->write('FOO!');
+        return $response;
+    })
+));
 
 $server->listen(new NoopFinalHandler());
 ```
 
-In the above example, we have two examples of middleware. The first is a
-landing page, and listens at the root path. If the request path is empty or
-`/`, it completes the response. If it is not, it delegates to the next
-middleware in the stack. The second middleware matches on the path `/foo`
+In the above example, we have two examples of middleware. The first is a landing
+page, and listens to every request. If the request path is empty or `/`, it
+completes the response. If it is not, it passes off request handling to the
+middleware in the stack. The second middleware matches only on the path `/foo`
 &mdash; meaning it will match `/foo`, `/foo/`, and any path beneath. In that
 case, it will complete the response with its own message. If no paths match at
-this point, a "final handler" is composed by default to report 404 status.
+this point, a "final handler" is composed by default to report a 404 status.
 
-So, concisely put, _middleware are PHP callables that accept a request and
-response object, and do something with it_.
+So, concisely put, _middleware accept a request, and decide if they can handle
+it and return a response, or need to delegate to another handler_.
 
-> ### http-interop middleware
+> ### Middleware types
 >
-> The above example demonstrates the legacy (pre-1.3.0) signature for
-> middleware, which is also widely used across other middleware frameworks
-> such as Slim, Relay, Adroit, etc.
+> Stratigility allows a number of different types of middleware.
 >
-> http-interop is a project attempting to standardize middleware signatures.
-> The signature until the 0.4.0 series for server-side middleware is:
->
-> ```php
-> namespace Interop\Http\Middleware;
->
-> use Psr\Http\Message\ResponseInterface;
-> use Psr\Http\Message\ServerRequestInterface;
->
-> interface ServerMiddlewareInterface
-> {
->     public function process(
->         ServerRequestInterface $request,
->         DelegateInterface $delegate
->     ) : ResponseInterface;
-> }
-> ```
->
-> where `DelegateInterface` is defined as:
->
-> ```php
-> namespace Interop\Http\Middleware;
->
-> use Psr\Http\Message\RequestInterface;
-> use Psr\Http\Message\ResponseInterface;
->
-> interface DelegateInterface
-> {
->     public function process(
->         RequestInterface $request
->     ) : ResponseInterface;
-> }
-> ```
->
-> Starting in http-interop/http-middleware 0.4.1, these become:
->
-> ```php
-> namespace Interop\Http\ServerMiddleware;
->
-> use Psr\Http\Message\ResponseInterface;
-> use Psr\Http\Message\ServerRequestInterface;
->
-> interface MiddlewareInterface
-> {
->     public function process(
->         ServerRequestInterface $request,
->         DelegateInterface $delegate
->     ) : ResponseInterface;
-> }
->
-> interface DelegateInterface
-> {
->     public function process(
->         ServerRequestInterface $request
->     ) : ResponseInterface;
-> }
-> ```
->
-> (Note the namespace change, the change in the middleware interface name, and
-> the change in the `DelegateInterface` signature.)
->
-> http-interop/http-middleware 0.5.0 changes the namespace, renames the delegate
-> to a request handler, and correspondingly changes the delegation method to
-> `handle()`:
->
-> ```php
-> namespace Interop\Http\Server;
->
-> use Psr\Http\Message\ResponseInterface;
-> use Psr\Http\Message\ServerRequestInterface;
->
-> interface MiddlewareInterface
-> {
->     public function process(
->         ServerRequestInterface $request,
->         RequestHandlerInterface $handler
->     ) : ResponseInterface;
-> }
->
-> interface RequestHandlerInterface
-> {
->     public function handle(
->         ServerRequestInterface $request
->     ) : ResponseInterface;
-> }
-> ```
->
-> Stratigility allows you to implement the http-interop/http-middleware
-> middleware interface to provide middleware.  Additionally, you can define
-> `callable` middleware with the following signature, and it will be dispatched
-> as http-interop middleware.
->
-> When using http-interop/http-middleware versions prior to 0.5, callable
-> middleware will look like this:
->
-> ```php
-> function(
->     ServerRequestInterface $request,
->     DelegateInterface $delegate
-> ) : ResponseInterface;
-> ```
->
-> When using http-interop/http-middleware versions 0.5.0 and above, it becomes:
->
-> ```php
-> function(
->     ServerRequestInterface $request,
->     HandlerRequestInterface $handler
-> ) : ResponseInterface;
-> ```
->
-> (In both examples above, the `$request` argument does not require a typehint
-> when defining callable middleware, but we encourage its use.)
->
-> As such, the above example can also be written as follows:
->
-> ```php
-> // Using http-interop/http-middleware 0.4.1:
-> $app->pipe('/', function ($request, DelegateInterface $delegate) {
->     if (! in_array($request->getUri()->getPath(), ['/', ''], true)) {
->         return $delegate->process($request);
->     }
->     return new TextResponse('Hello world!');
-> });
->
-> // Using http-interop/http-middleware 0.5.0:
-> $app->pipe('/', function ($request, RequestHandlerInterface $handler) {
->     if (! in_array($request->getUri()->getPath(), ['/', ''], true)) {
->         return $handler->handle($request);
->     }
->     return new TextResponse('Hello world!');
-> });
-> ```
+> The type demonstrated above is callable middleware based on an
+> interface signature that forms the basis of the [proposed PSR-15
+standard](https://github.com/php-fig/fig-standards/tree/4b417c91b89fbedaf3283620ce432b6f51c80cc0/proposed/http-handlers).
+> 
+> Stratigility also supports:
+> 
+> - Callable "double pass" middleware.
+> - Middleware implementing the proposed PSR-15 `MiddlewareInterface`.
+> 
+> For more details on the various middleware types accepted, including their
+> signatures, please read the [chapter on creating middleware](creating-middleware.md).
 
-Middleware can decide more processing can be performed by calling the `$next`
-callable (or, when defining http-interop middleware, `$delegate`/`$handler`)
-passed during invocation. With this paradigm, you can build a workflow engine
-for handling requests &mdash; for instance, you could have middleware perform
-the following:
+Middleware can decide more processing can be performed by calling on the
+`$handler` argument passed during invocation. With this paradigm, you can build
+a workflow engine for handling requests &mdash; for instance, you could have
+middleware perform the following:
 
 - Handle authentication details
 - Perform content negotiation
@@ -205,29 +88,11 @@ example, you could put API middleware next to middleware that serves its
 documentation, next to middleware that serves files, and segregate each by URI:
 
 ```php
-$app->pipe('/api', $apiMiddleware);
-$app->pipe('/docs', $apiDocMiddleware);
-$app->pipe('/files', $filesMiddleware);
+$app->pipe(new PathMiddlewareDecorator('/api', $apiMiddleware));
+$app->pipe(new PathMiddlewareDecorator('/docs', $apiDocMiddleware));
+$app->pipe(new PathMiddlewareDecorator('/files', $filesMiddleware));
 ```
 
 The handlers in each middleware attached this way will see a URI with that path
 segment stripped, allowing them to be developed separately and re-used under
 any path you wish.
-
-Within Stratigility, middleware can be:
-
-- Any PHP callable that accepts, minimally, a
-  [PSR-7](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md)
-  ServerRequest and Response (in that order), and, optionally, a callable (for
-  invoking the next middleware in the queue, if any).
-- Any [http-interop 0.2.0 - middleware](https://github.com/http-interop/http-middleware/tree/0.2.0).
-  `Zend\Stratigility\MiddlewarePipe` implements
-  `Interop\Http\Middleware\ServerMiddlewareInterface`. (Stratigility 1.3.0 series.)
-- Any [http-interop 0.4.1 - middleware](https://github.com/http-interop/http-middleware/tree/0.4.1).
-  `Zend\Stratigility\MiddlewarePipe` implements
-  `Interop\Http\ServerMiddleware\MiddlewareInterface`. (Stratigility 2.0 series.)
-- Any [http-interop 0.5.0 - middleware](https://github.com/http-interop/http-middleware/tree/0.5.0).
-  `Zend\Stratigility\MiddlewarePipe` implements
-  `Interop\Http\Server\MiddlewareInterface`. (Since Stratigility 2.1)
-- An object implementing `Zend\Stratigility\MiddlewareInterface`.
-  (Legacy; this interface is deprecated starting in 1.3.0.)

--- a/docs/book/migration/preparing-for-v3.md
+++ b/docs/book/migration/preparing-for-v3.md
@@ -1,0 +1,179 @@
+# Preparing for version 3
+
+- Since 2.2.0
+
+Version 3 simplifies `MiddlewarePipe` and `Next` dramatically by restricting
+them to [PSR-15](https://github.com/php-fig/fig-standards/tree/4b417c91b89fbedaf3283620ce432b6f51c80cc0/proposed/http-handlers)
+interface implementations and typehints. However, this also means a number of
+backwards compatibility breaks are coming.
+
+To help prepare you for the new version, we have provided a number of features
+you can adopt today in order to make your code forwards-compatible.
+Additionally, we have marked classes and methods as deprecated where necessary,
+and trigger `E_USER_DEPRECATED` errors when using functionality which will no
+longer be available.
+
+Below, we list the various changes, and propose ways in which you can update
+your code to be forwards-compatible.
+
+## MiddlewarePipe and path segregation
+
+Starting in version 3, `MiddlewarePipe` and `Next` have significantly
+different behavior.
+
+First, the signature of `MiddlewarePipe::pipe()` will change to:
+
+```php
+public function pipe(
+    MiddlewareInterface $middleware
+) : void
+```
+
+This means the following:
+
+- You can no longer use `pipe()` to perform path segregation.
+- You can no longer pipe callable middleware of any type.
+
+To support path segregation, we have introduced
+`Zend\Stratigility\Middleware\PathMiddlewareDecorator`. This class accepts two
+arguments to its constructor: a string `$pathPrefix` (previously, the `$path`
+argument to `MiddlewarePipe::pipe()`), and a middleware implementation. This
+class has been backported to version 2.2.0, with usage as follows:
+
+```php
+// Previously:
+$pipeline->pipe('/api', $apiMiddleware);
+
+// Version 2.2.0+:
+$pipeline->pipe(new PathMiddlewareDecorator('/api', $apiMiddleware));
+```
+
+Path segregation using this middleware works exactly as it has in previous
+versions. (Internally, if you provide both a `$path` and `$middleware` argument,
+`MiddlewarePipe::pipe()` creates a `PathMiddlewareDecorator` instance from the
+two arguments).
+
+**Decorate middleware you need to segregate by path using
+`PathMiddlewareDecorator`.**
+
+To support callable middleware, we have introduced two classes:
+
+- `Zend\Stratigility\Middleware\CallableMiddlewareDecorator` can be used to
+  decorate callable middleware following the PSR-15 signature. It replaces the
+  class `CallableInteropMiddlewareWrapper`.
+
+- `Zend\Stratigility\Middleware\DoublePassMiddlewareDecorator` can be used to
+  decorate callable middleware following the double-pass signature. It replaces
+  the class `CallableMiddlewareWrapper`.
+
+Use these classes to decorate your callable middleware when piping them:
+
+```php
+// Previously (interop middleware):
+$pipeline->pipe(function ($request, $delegate) {
+    /* ... */
+});
+
+// Version 2.2.0+:
+$pipeline->pipe(new CallableMiddlewareDecorator(function ($request, $delegate) {
+    /* ... */
+}));
+
+// Previously (double-pass middleware):
+$pipeline->pipe(function ($request, $response, $next) {
+    /* ... */
+});
+
+// Version 2.2.0+:
+$pipeline->pipe(new DoublePassMiddlewareDecorator(function ($request, $response, $next) {
+    /* ... */
+}));
+```
+
+If you pipe callables directly, you will now trigger an `E_USER_DEPRECATION`
+error. Internally, `MiddlewarePipe::pipe()` will decorate them using the classes
+noted above.
+
+**Decorate callable middleware before piping using either
+`CallableMiddlewareDecorator` or `DoublePassMiddlewareDecorator`.**
+
+## Extending MiddlewarePipe
+
+Starting in version 3, `Zend\Stratigility\MiddlewarePipe` is marked as `final`.
+This means you will no longer be able to directly extend it.
+
+We recommend the following:
+
+- If you are extending the class for the sole purpose of piping specific
+  middleware, create a PSR-15 `MiddlewareInterface` implementation, and compose
+  a `MiddlewarePipe` internally; have your `process()` method proxy to it.
+  (You could also optionally implement `RequestHandlerInterface`, which
+  `MiddlewarePipe` does in version 3.)
+
+- If you are extending the class in order to provide additional features or
+  override methods, create your own PSR-15 `MiddlewareInterface` implementation
+  to do so, and copy and paste methods from `MiddlewarePipe` as needed,
+  providing the changes you need within your version.
+
+## Deprecated classes
+
+The following classes are now marked as deprecated. Where alternatives are
+available, we note them. If no alternative is available, we note why.
+
+### `Zend\Stratigility\MiddlewareInterface`
+
+This interface has been marked as deprecated since 2.0.0, and unused internally
+since that release. It is removed with version 3.0.0.
+
+### `Zend\Stratigility\Route`
+
+This is an internal message shared between a `MiddlewarePipe` and a `Next`
+instance for purposes of path segregation. In general, it should never be
+consumed directly; however, it was never marked as internal or final previously.
+
+If you are extending this class or manipulating instances manually, be aware
+that this class is removed in version 3 as it is no longer used internally.
+
+### `Zend\Stratigility\Exception\InvalidMiddlewareException`
+
+This was thrown by `MiddlewarePipe::pipe()`. In version 3, since the sole
+argument to that method is type-hinted against the PSR-15 `MiddlewareInterface`,
+it is no longer used.
+
+### `Zend\Stratigility\Exception\InvalidRequestTypeException`
+
+This has not been used internally since before version 2.
+
+### `Zend\Stratigility\Delegate\CallableDelegateDecorator`
+
+This was an internal class used by several classes when they were being used
+within double-pass systems in order to cast a `callable $next` argument into a
+`Interop\Http\ServerMiddleware\DelegateInterface` instance. Since version 3 will
+no longer support operation directly within a double-pass architecture, this
+class will be removed.
+
+Methods that produce an instance include:
+- `MiddlewarePipe::__invoke()`
+- `NotFoundHandler::__invoke()`
+- `ErrorHandler::__invoke()`
+
+### `Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper`
+
+This class has been deprecated in favor of a new class,
+`Zend\Stratigility\Middleware\CallableMiddlewareDecorator`.
+
+### `Zend\Stratigility\Middleware\CallableMiddlewareWrapper`
+
+This class has been deprecated in favor of a new class,
+`Zend\Stratigility\Middleware\DoublePassMiddlewareDecorator`.
+
+### `Zend\Stratigility\Middleware\CallableMiddlewareWrapperFactory`
+
+The primary purpose of this class was for composition within a `MiddlewarePipe`
+for purposes of decorating callable double-pass middleware. Since
+`MiddlewarePipe::pipe()` will no longer accept callables, it will also no longer
+need to compose this factory.
+
+### `Zend\Stratigility\Middleware\NoopFinalFactory`
+
+This class has no internal usage, and is removed in version 3.

--- a/docs/book/migration/preparing-for-v3.md
+++ b/docs/book/migration/preparing-for-v3.md
@@ -45,7 +45,12 @@ class has been backported to version 2.2.0, with usage as follows:
 $pipeline->pipe('/api', $apiMiddleware);
 
 // Version 2.2.0+:
+use Zend\Stratigility\Middleware\PathMiddlewareDecorator;
 $pipeline->pipe(new PathMiddlewareDecorator('/api', $apiMiddleware));
+
+// OR:
+use Zend\Stratigility\path;
+$pipeline->pipe(path('/api', $apiMiddleware));
 ```
 
 Path segregation using this middleware works exactly as it has in previous
@@ -54,7 +59,7 @@ versions. (Internally, if you provide both a `$path` and `$middleware` argument,
 two arguments).
 
 **Decorate middleware you need to segregate by path using
-`PathMiddlewareDecorator`.**
+`PathMiddlewareDecorator` or the `path()` utility function.**
 
 To support callable middleware, we have introduced two classes:
 
@@ -75,7 +80,13 @@ $pipeline->pipe(function ($request, $delegate) {
 });
 
 // Version 2.2.0+:
+use Zend\Stratigility\Middleware\CallableMiddlewareDecorator;
+use Zend\Stratigility\middleware;
 $pipeline->pipe(new CallableMiddlewareDecorator(function ($request, $delegate) {
+    /* ... */
+}));
+// or:
+$pipeline->pipe(middleware(function ($request, $delegate) {
     /* ... */
 }));
 
@@ -85,7 +96,13 @@ $pipeline->pipe(function ($request, $response, $next) {
 });
 
 // Version 2.2.0+:
+use Zend\Stratigility\Middleware\DoublePassMiddlewareDecorator;
+use Zend\Stratigility\doublePassMiddleware;
 $pipeline->pipe(new DoublePassMiddlewareDecorator(function ($request, $response, $next) {
+    /* ... */
+}));
+// or:
+$pipeline->pipe(doublePassMiddleware(function ($request, $response, $next) {
     /* ... */
 }));
 ```
@@ -95,7 +112,8 @@ error. Internally, `MiddlewarePipe::pipe()` will decorate them using the classes
 noted above.
 
 **Decorate callable middleware before piping using either
-`CallableMiddlewareDecorator` or `DoublePassMiddlewareDecorator`.**
+`CallableMiddlewareDecorator` or `DoublePassMiddlewareDecorator` or the relevant
+utility functions as noted in the examples above.**
 
 ## Extending MiddlewarePipe
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,10 +9,11 @@ pages:
         - Middleware: middleware.md
         - "Error Handlers": error-handlers.md
         - "Creating Middleware": creating-middleware.md
-        - "Executing and composing middleware": executing-middleware.md
+        - "Composing middleware": executing-middleware.md
         - "API Reference": api.md
         - Migration:
           - "To Version 2": migration/to-v2.md
+          - "Preparing for Version 3": migration/preparing-for-v3.md
 site_name: zend-stratigility
 site_description: zend-stratigility
 repo_url: 'https://github.com/zendframework/zend-stratigility'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,9 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
+            <exclude>
+                <file>./src/Middleware/CallableMiddlewareWrapperFactory.php</file>
+            </exclude>
         </whitelist>
     </filter>
 </phpunit>

--- a/src/Delegate/CallableDelegateDecorator.php
+++ b/src/Delegate/CallableDelegateDecorator.php
@@ -15,6 +15,10 @@ use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface
 /**
  * Decorate callable delegates as http-interop delegates in order to process
  * incoming requests.
+ *
+ * @deprecated since 2.2.0; to be removed in 3.0.0. This class is an internal
+ *     detail used to allow usage of Stratigility within double-pass middleware
+ *     frameworks; starting in 3.0.0, Stratigility will support PSR-15 only.
  */
 class CallableDelegateDecorator implements DelegateInterface
 {

--- a/src/Delegate/CallableDelegateDecorator.php
+++ b/src/Delegate/CallableDelegateDecorator.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Delegate/CallableDelegateDecorator.php
+++ b/src/Delegate/CallableDelegateDecorator.php
@@ -66,11 +66,15 @@ class CallableDelegateDecorator implements DelegateInterface
     /**
      * Method provided for compatibility with http-interop/http-middleware 0.1.1.
      *
+     * This method duplicates handle(), as a RequestInterface may or
+     * may not be a ServerRequestInterface instance.
+     *
      * @param RequestInterface $request
      * @return mixed
      */
     public function next(RequestInterface $request)
     {
-        return $this->handle($request);
+        $delegate = $this->delegate;
+        return $delegate($request, $this->response);
     }
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Exception;
+
+/**
+ * @deprecated since 2.2.0; to be removed in 3.0.0. The need for this class
+ *     disappears with strict types in PHP 7.
+ */
+class InvalidArgumentException extends \InvalidArgumentException
+{
+}

--- a/src/Exception/InvalidMiddlewareException.php
+++ b/src/Exception/InvalidMiddlewareException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/InvalidMiddlewareException.php
+++ b/src/Exception/InvalidMiddlewareException.php
@@ -9,6 +9,9 @@ namespace Zend\Stratigility\Exception;
 
 use InvalidArgumentException;
 
+/**
+ * @deprecated since 2.2.0; to be removed in 3.0.0.
+ */
 class InvalidMiddlewareException extends InvalidArgumentException
 {
     /**

--- a/src/Exception/InvalidRequestTypeException.php
+++ b/src/Exception/InvalidRequestTypeException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/InvalidRequestTypeException.php
+++ b/src/Exception/InvalidRequestTypeException.php
@@ -12,6 +12,8 @@ use RuntimeException;
 /**
  * Exception thrown when Dispatch::process() is called with a non-interop
  * handler provided, and the request is not a server request type.
+ *
+ * @deprecated since 2.2.0; to be removed in 3.0.0. No longer used internally.
  */
 class InvalidRequestTypeException extends RuntimeException
 {

--- a/src/Exception/MissingResponseException.php
+++ b/src/Exception/MissingResponseException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/MissingResponseException.php
+++ b/src/Exception/MissingResponseException.php
@@ -15,4 +15,14 @@ use OutOfBoundsException;
  */
 class MissingResponseException extends OutOfBoundsException
 {
+    public static function forCallableMiddleware(callable $middleware)
+    {
+        $type = is_object($middleware)
+            ? get_class($middleware)
+            : gettype($middleware);
+        return new self(sprintf(
+            'Decorated callable middleware of type %s failed to produce a response.',
+            $type
+        ));
+    }
 }

--- a/src/Exception/PathOutOfSyncException.php
+++ b/src/Exception/PathOutOfSyncException.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Exception;
+
+use RuntimeException;
+
+class PathOutOfSyncException extends RuntimeException
+{
+    /**
+     * @param string $pathPrefix
+     * @param string $path
+     * @return self
+     */
+    public static function forPath($pathPrefix, $path)
+    {
+        return new self(sprintf(
+            'Layer path "%s" and request path "%s" are out of sync; cannot dispatch'
+            . ' middleware layer',
+            $pathPrefix,
+            $path
+        ));
+    }
+}

--- a/src/Middleware/CallableInteropMiddlewareWrapper.php
+++ b/src/Middleware/CallableInteropMiddlewareWrapper.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/CallableInteropMiddlewareWrapper.php
+++ b/src/Middleware/CallableInteropMiddlewareWrapper.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
+/**
+ * @deprecated since 2.2.0; to be removed in 3.0.0. Use CallableMiddlewareDecorator instead.
+ */
 class CallableInteropMiddlewareWrapper implements ServerMiddlewareInterface
 {
     /**

--- a/src/Middleware/CallableMiddlewareDecorator.php
+++ b/src/Middleware/CallableMiddlewareDecorator.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/CallableMiddlewareDecorator.php
+++ b/src/Middleware/CallableMiddlewareDecorator.php
@@ -49,7 +49,8 @@ class CallableMiddlewareDecorator implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler)
     {
-        $response = ($this->middleware)($request, $handler);
+        $middleware = $this->middleware;
+        $response = $middleware($request, $handler);
         if (! $response instanceof ResponseInterface) {
             throw Exception\MissingResponseException::forCallableMiddleware($this->middleware);
         }

--- a/src/Middleware/CallableMiddlewareDecorator.php
+++ b/src/Middleware/CallableMiddlewareDecorator.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use Zend\Stratigility\Exception;
+
+/**
+ * Decorate callable middleware as PSR-15 middleware.
+ *
+ * Decorates middleware with the following signature:
+ *
+ * <code>
+ * function (
+ *     ServerRequestInterface $request,
+ *     RequestHandlerInterface $handler
+ * ) : ResponseInterface
+ * </code>
+ *
+ * such that it will operate as PSR-15 middleware.
+ *
+ * Neither the arguments nor the return value need be typehinted; however, if
+ * the signature is incompatible, a PHP Error will likely be thrown.
+ */
+class CallableMiddlewareDecorator implements MiddlewareInterface
+{
+    /**
+     * @var callable
+     */
+    private $middleware;
+
+    public function __construct(callable $middleware)
+    {
+        $this->middleware = $middleware;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws Exception\MissingResponseException if the decorated middleware
+     *     fails to produce a response.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler)
+    {
+        $response = ($this->middleware)($request, $handler);
+        if (! $response instanceof ResponseInterface) {
+            throw Exception\MissingResponseException::forCallableMiddleware($this->middleware);
+        }
+        return $response;
+    }
+}

--- a/src/Middleware/CallableMiddlewareWrapper.php
+++ b/src/Middleware/CallableMiddlewareWrapper.php
@@ -18,6 +18,8 @@ use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 /**
  * Decorate legacy callable middleware to make it dispatchable as server
  * middleware.
+ *
+ * @deprecated since 2.2.0; to be removed in 3.0.0. Use DoublePassMiddlewareDecorator instead.
  */
 class CallableMiddlewareWrapper implements ServerMiddlewareInterface
 {

--- a/src/Middleware/CallableMiddlewareWrapper.php
+++ b/src/Middleware/CallableMiddlewareWrapper.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/CallableMiddlewareWrapperFactory.php
+++ b/src/Middleware/CallableMiddlewareWrapperFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/CallableMiddlewareWrapperFactory.php
+++ b/src/Middleware/CallableMiddlewareWrapperFactory.php
@@ -9,6 +9,9 @@ namespace Zend\Stratigility\Middleware;
 
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @deprecated since 2.2.0; to be removed in 3.0.0.
+ */
 class CallableMiddlewareWrapperFactory
 {
     /**

--- a/src/Middleware/DoublePassMiddlewareDecorator.php
+++ b/src/Middleware/DoublePassMiddlewareDecorator.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/DoublePassMiddlewareDecorator.php
+++ b/src/Middleware/DoublePassMiddlewareDecorator.php
@@ -68,7 +68,8 @@ class DoublePassMiddlewareDecorator implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler)
     {
-        $response = ($this->middleware)(
+        $middleware = $this->middleware;
+        $response = $middleware(
             $request,
             $this->responsePrototype,
             $this->decorateHandler($handler)

--- a/src/Middleware/DoublePassMiddlewareDecorator.php
+++ b/src/Middleware/DoublePassMiddlewareDecorator.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use Zend\Diactoros\Response;
+use Zend\Stratigility\Exception;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+/**
+ * Decorate double-pass middleware as PSR-15 middleware.
+ *
+ * Decorates middleware with the following signature:
+ *
+ * <code>
+ * function (
+ *     ServerRequestInterface $request,
+ *     ResponseInterface $response,
+ *     callable $next
+ * ) : ResponseInterface
+ * </code>
+ *
+ * such that it will operate as PSR-15 middleware.
+ *
+ * Neither the arguments nor the return value need be typehinted; however, if
+ * the signature is incompatible, a PHP Error will likely be thrown.
+ */
+class DoublePassMiddlewareDecorator implements MiddlewareInterface
+{
+    /**
+     * @var callable
+     */
+    private $middleware;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    /**
+     * @throws Exception\MissingResponsePrototypeException if no response
+     *     prototype is present, and zend-diactoros is not installed.
+     */
+    public function __construct(callable $middleware, ResponseInterface $responsePrototype = null)
+    {
+        $this->middleware = $middleware;
+
+        if (! $responsePrototype && ! class_exists(Response::class)) {
+            throw Exception\MissingResponsePrototypeException::create();
+        }
+
+        $this->responsePrototype = $responsePrototype ?: new Response();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws Exception\MissingResponseException if the decorated middleware
+     *     fails to produce a response.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler)
+    {
+        $response = ($this->middleware)(
+            $request,
+            $this->responsePrototype,
+            $this->decorateHandler($handler)
+        );
+
+        if (! $response instanceof ResponseInterface) {
+            throw Exception\MissingResponseException::forCallableMiddleware($this->middleware);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @return callable
+     */
+    private function decorateHandler(RequestHandlerInterface $handler)
+    {
+        return function ($request, $response) use ($handler) {
+            return $handler->{HANDLER_METHOD}($request);
+        };
+    }
+}

--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -100,6 +100,7 @@ final class ErrorHandler implements ServerMiddlewareInterface
      * Proxies to process, after first wrapping the `$next` argument using the
      * CallableDelegateDecorator.
      *
+     * @deprecated since 2.2.0; to be removed in version 3.0. Use process() instead.
      * @param ServerRequestInterface $request
      * @param ResponseInterface $response
      * @param callable $next

--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -35,6 +35,7 @@ class NotFoundHandler implements ServerMiddlewareInterface
      * Proxies to process, after first wrapping the `$next` argument using the
      * CallableDelegateDecorator.
      *
+     * @deprecated since 2.2.0; to be removed in version 3.0. Use process() instead.
      * @param ServerRequestInterface $request
      * @param ResponseInterface $response
      * @param callable $next

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/PathMiddlewareDecorator.php
+++ b/src/Middleware/PathMiddlewareDecorator.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use Zend\Stratigility\Exception;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+class PathMiddlewareDecorator implements MiddlewareInterface
+{
+    /** @var MiddlewareInterface */
+    private $middleware;
+
+    /** @var string Path prefix under which the middleware is segregated.  */
+    private $prefix;
+
+    /**
+     * @param string $prefix
+     */
+    public function __construct($prefix, MiddlewareInterface $middleware)
+    {
+        if (! is_string($prefix)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '$prefix argument to %s must be a string; received %s',
+                __CLASS__,
+                is_object($prefix) ? get_class($prefix) : gettype($prefix)
+            ));
+        }
+        $this->prefix = $this->normalizePrefix($prefix);
+        $this->middleware = $middleware;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler)
+    {
+        $path = $request->getUri()->getPath();
+        $path = $path ?: '/';
+
+        // Current path is shorter than decorator path
+        if (strlen($path) < strlen($this->prefix)) {
+            return $handler->{HANDLER_METHOD}($request);
+        }
+
+        // Current path does not match decorator path
+        if (substr(strtolower($path), 0, strlen($this->prefix)) !== strtolower($this->prefix)) {
+            return $handler->{HANDLER_METHOD}($request);
+        }
+
+        // Skip if match is not at a border ('/', '.', or end)
+        $border = $this->getBorder($path);
+        if ($border && '/' !== $border && '.' !== $border) {
+            return $handler->{HANDLER_METHOD}($request);
+        }
+
+        // Trim off the part of the url that matches the prefix if it is non-empty
+        $requestToProcess = (! empty($this->prefix) && $this->prefix !== '/')
+            ? $this->prepareRequestWithTruncatedPrefix($request)
+            : $request;
+
+        // Process our middleware.
+        // If the middleware calls on the handler, the handler should be provided
+        // the original request, as this indicates we've left the path-segregated
+        // layer.
+        return $this->middleware->process(
+            $requestToProcess,
+            new PathRequestHandlerDecorator($handler, $request)
+        );
+    }
+
+    /**
+     * @param string $path
+     * @return string
+     */
+    private function getBorder($path)
+    {
+        if ($this->prefix === '/') {
+            return '/';
+        }
+
+        $length = strlen($this->prefix);
+        return strlen($path) > $length ? $path[$length] : '';
+    }
+
+    /**
+     * @return ServerRequestInterface
+     */
+    private function prepareRequestWithTruncatedPrefix(ServerRequestInterface $request)
+    {
+        $uri  = $request->getUri();
+        $path = $this->getTruncatedPath($this->prefix, $uri->getPath());
+        $new  = $uri->withPath($path);
+        return $request->withUri($new);
+    }
+
+    /**
+     * @param string $segment
+     * @param string $path
+     * @return string
+     */
+    private function getTruncatedPath($segment, $path)
+    {
+        if ($segment === $path) {
+            // Decorated path and current path are the same; return empty string
+            return '';
+        }
+
+        $length = strlen($segment);
+        if (strlen($path) > $length) {
+            // Strip decorated path from start of current path
+            return substr($path, $length);
+        }
+
+        if ('/' === substr($segment, -1)) {
+            // Re-try by submitting with / stripped from end of segment
+            return $this->getTruncatedPath(rtrim($segment, '/'), $path);
+        }
+
+        // Segment is longer than path; this is a problem.
+        throw Exception\PathOutOfSyncException::forPath($this->prefix, $path);
+    }
+
+    /**
+     * Ensures that the right-most slash is trimmed for prefixes of more than
+     * one character, and that the prefix begins with a slash.
+     *
+     * @param string $prefix
+     * @return string
+     */
+    private function normalizePrefix($prefix)
+    {
+        $prefix = strlen($prefix) > 1 ? rtrim($prefix, '/') : $prefix;
+        if ('/' !== substr($prefix, 0, 1)) {
+            $prefix = '/' . $prefix;
+        }
+        return $prefix;
+    }
+}

--- a/src/Middleware/PathMiddlewareDecorator.php
+++ b/src/Middleware/PathMiddlewareDecorator.php
@@ -103,6 +103,8 @@ class PathMiddlewareDecorator implements MiddlewareInterface
      * @param string $segment
      * @param string $path
      * @return string
+     * @throws Exception\PathOutOfSyncException if path prefix is longer than
+     *     the path
      */
     private function getTruncatedPath($segment, $path)
     {

--- a/src/Middleware/PathRequestHandlerDecorator.php
+++ b/src/Middleware/PathRequestHandlerDecorator.php
@@ -7,6 +7,7 @@
 
 namespace Zend\Stratigility\Middleware;
 
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
 
@@ -51,5 +52,14 @@ class PathRequestHandlerDecorator implements RequestHandlerInterface
         $uri = $request->getUri()
             ->withPath($this->originalRequest->getUri()->getPath());
         return $this->handler->{HANDLER_METHOD}($request->withUri($uri));
+    }
+
+    /**
+     * Proxy to handle
+     * {@inheritDocs}
+     */
+    public function next(RequestInterface $request)
+    {
+        return $this->handle($request);
     }
 }

--- a/src/Middleware/PathRequestHandlerDecorator.php
+++ b/src/Middleware/PathRequestHandlerDecorator.php
@@ -48,6 +48,8 @@ class PathRequestHandlerDecorator implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request)
     {
-        return $this->handler->{HANDLER_METHOD}($this->originalRequest);
+        $uri = $request->getUri()
+            ->withPath($this->originalRequest->getUri()->getPath());
+        return $this->handler->{HANDLER_METHOD}($request->withUri($uri));
     }
 }

--- a/src/Middleware/PathRequestHandlerDecorator.php
+++ b/src/Middleware/PathRequestHandlerDecorator.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+/**
+ * Request handler decorator for the PathMiddlewareDecorator
+ *
+ * Wraps the original request and original request handler passed when processing
+ * a PathMiddlewareDecorator. If the decorated middleware calls on the handler
+ * provided to it, this decorator ensures that the original handler is called,
+ * using the original request.
+ *
+ * @internal This class is an internal detail of the PathMiddlewareDecorator.
+ * @deprecated since 2.2.0; to be removed in 3.0, where it can be replaced with
+ *     an anonymous class implementation.
+ */
+class PathRequestHandlerDecorator implements RequestHandlerInterface
+{
+    /**
+     * @var RequestHandlerInterface
+     */
+    private $handler;
+
+    /**
+     * @var ServerRequestInterface
+     */
+    private $originalRequest;
+
+    public function __construct(RequestHandlerInterface $handler, ServerRequestInterface $originalRequest)
+    {
+        $this->handler = $handler;
+        $this->originalRequest = $originalRequest;
+    }
+
+    /**
+     * Invokes the composed handler with the original server request.
+     * {@inheritDocs}
+     */
+    public function handle(ServerRequestInterface $request)
+    {
+        return $this->handler->{HANDLER_METHOD}($this->originalRequest);
+    }
+}

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -72,6 +72,7 @@ class MiddlewarePipe implements ServerMiddlewareInterface
      * accepting at least a request instance (in such cases, the delegate
      * will be decorated using Delegate\CallableDelegateDecorator).
      *
+     * @deprecated since 2.2.0; to be removed in version 3.0. Use process() instead.
      * @param Request $request
      * @param Response $response
      * @param callable|DelegateInterface $delegate
@@ -116,7 +117,11 @@ class MiddlewarePipe implements ServerMiddlewareInterface
      * @see MiddlewareInterface
      * @see Next
      * @param string|callable|object $path Either a URI path prefix, or middleware.
-     * @param null|callable|object $middleware Middleware
+     *     Note: since v2.2.0, we have deprecated usage of any argument type other
+     *     than a middleware implementation.
+     * @param null|callable|object $middleware Middleware. Note: since v2.2.0, we
+     *     have deprecated usage of this argument. Use the PathMiddlewareDecorator
+     *     to segregate middleware by path.
      * @return self
      */
     public function pipe($path, $middleware = null)

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Next.php
+++ b/src/Next.php
@@ -160,7 +160,7 @@ class Next implements DelegateInterface
         $path = $route->path;
         $middleware = $route->handler;
 
-        if (! in_array($path, ['', '/'])
+        if (! in_array($path, ['', '/'], true)
             && ! $middleware instanceof Middleware\PathMiddlewareDecorator
         ) {
             return new Middleware\PathMiddlewareDecorator($path, $middleware);

--- a/src/Next.php
+++ b/src/Next.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Next.php
+++ b/src/Next.php
@@ -60,6 +60,7 @@ class Next implements DelegateInterface
      *
      * Ignores any arguments other than the request.
      *
+     * @deprecated starting in 2.2.0, to remove in 3.0.0. Use handle() instead.
      * @param ServerRequestInterface $request
      * @return ResponseInterface
      * @throws Exception\MissingResponseException If the queue is exhausted, and
@@ -76,6 +77,8 @@ class Next implements DelegateInterface
      * Proxy to handle method.
      * It is needed to support http-interop/http-middleware 0.1.1.
      *
+     * @codeCoverageIgnore
+     * @deprecated starting in 2.2.0, to remove in 3.0.0. Use handle() instead.
      * @param RequestInterface $request
      * @return ResponseInterface
      */
@@ -88,6 +91,7 @@ class Next implements DelegateInterface
      * Proxy to handle method.
      * It is needed to support http-interop/http-middleware 0.2-0.4.1.
      *
+     * @deprecated starting in 2.2.0, to remove in 3.0.0. Use handle() instead.
      * @param ServerRequestInterface $request
      * @return ResponseInterface
      */
@@ -137,6 +141,7 @@ class Next implements DelegateInterface
     /**
      * Toggle the "raise throwables" flag on.
      *
+     * @codeCoverageIgnore
      * @deprecated Since 2.0.0; this functionality is now a no-op.
      * @return void
      */

--- a/src/NoopFinalHandler.php
+++ b/src/NoopFinalHandler.php
@@ -10,6 +10,9 @@ namespace Zend\Stratigility;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * @deprecated since 2.2.0; to be removed in 3.0.0.
+ */
 class NoopFinalHandler
 {
     /**

--- a/src/NoopFinalHandler.php
+++ b/src/NoopFinalHandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -46,7 +46,7 @@ class Route
 
         $this->path    = $path;
 
-        if (! in_array($this->path, ['', '/'])
+        if (! in_array($this->path, ['', '/'], true)
             && ! $handler instanceof Middleware\PathMiddlewareDecorator
         ) {
             trigger_error(sprintf(

--- a/src/Route.php
+++ b/src/Route.php
@@ -45,6 +45,19 @@ class Route
         }
 
         $this->path    = $path;
+
+        if (! in_array($this->path, ['', '/'])
+            && ! $handler instanceof Middleware\PathMiddlewareDecorator
+        ) {
+            trigger_error(sprintf(
+                'Providing a path to a %s instance is deprecated; please use the'
+                . ' %s to decorate your path-segregated middleware instead.',
+                __CLASS__,
+                Middleware\PathMiddlewareDecorator::class
+            ), E_USER_DEPRECATED);
+            $handler = new Middleware\PathMiddlewareDecorator($path, $handler);
+        }
+
         $this->handler = $handler;
     }
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -17,6 +17,8 @@ use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewa
  * Details the subpath on which the middleware is active, and the
  * handler for the middleware itself.
  *
+ * @internal
+ * @deprecated since 2.2.0, to be removed in 3.0.0.
  * @property-read callable $handler Handler for this route
  * @property-read string $path Path for this route
  */

--- a/src/functions/double-pass-middleware.php
+++ b/src/functions/double-pass-middleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/functions/double-pass-middleware.php
+++ b/src/functions/double-pass-middleware.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Convenience wrapper around instantiation of a DoublePassMiddlewareDecorator instance.
+ *
+ * Usage:
+ *
+ * <code>
+ * $pipeline->pipe(doublePassMiddleware(function ($req, $res, $next) {
+ *     // do some work
+ * }));
+ * </code>
+ *
+ * Optionally, pass a response prototype as well, if using a PSR-7
+ * implementation other than zend-diactoros:
+ *
+ * <code>
+ * $pipeline->pipe(doublePassMiddleware(function ($req, $res, $next) {
+ *     // do some work
+ * }, $responsePrototype));
+ * </code>
+ *
+ * @return Middleware\DoublePassMiddlewareDecorator
+ */
+function doublePassMiddleware(
+    callable $middleware,
+    ResponseInterface $response = null
+) {
+    return new Middleware\DoublePassMiddlewareDecorator($middleware, $response);
+}

--- a/src/functions/middleware.php
+++ b/src/functions/middleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/functions/middleware.php
+++ b/src/functions/middleware.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Convenience wrapper around instantiation of a CallableMiddlewareDecorator instance.
+ *
+ * Usage:
+ *
+ * <code>
+ * $pipeline->pipe(middleware(function ($req, $handler) {
+ *     // do some work
+ * }));
+ * </code>
+ *
+ * @return Middleware\CallableMiddlewareDecorator
+ */
+function middleware(callable $middleware)
+{
+    return new Middleware\CallableMiddlewareDecorator($middleware);
+}

--- a/src/functions/path.php
+++ b/src/functions/path.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/functions/path.php
+++ b/src/functions/path.php
@@ -7,6 +7,8 @@
 
 namespace Zend\Stratigility;
 
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+
 /**
  * Convenience function for creating path-segregated middleware.
  *

--- a/src/functions/path.php
+++ b/src/functions/path.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility;
+
+/**
+ * Convenience function for creating path-segregated middleware.
+ *
+ * Usage:
+ *
+ * <code>
+ * use function Zend\Stratigility\path;
+ *
+ * $pipeline->pipe(path('/foo', $middleware));
+ * </code>
+ *
+ * @param string $path Path prefix to match in order to dispatch $middleware
+ * @return Middleware\PathMiddlewareDecorator
+ */
+function path($path, MiddlewareInterface $middleware)
+{
+    return new Middleware\PathMiddlewareDecorator($path, $middleware);
+}

--- a/test/Delegate/CallableDelegateDecoratorTest.php
+++ b/test/Delegate/CallableDelegateDecoratorTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Stratigility\Delegate;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Stratigility\Delegate\CallableDelegateDecorator;
+
+class CallableDelegateDecoratorTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->response = $this->prophesize(ResponseInterface::class)->reveal();
+    }
+
+    public function testProcessWillProxyToComposedDelegate()
+    {
+        $originalRequest = $this->prophesize(ServerRequestInterface::class)->reveal();
+
+        $delegate = function ($request, $response) use ($originalRequest) {
+            Assert::assertSame($originalRequest, $request);
+            Assert::assertSame($this->response, $response);
+            return $response;
+        };
+
+        $decorator = new CallableDelegateDecorator($delegate, $this->response);
+
+        $this->assertSame($this->response, $decorator->process($originalRequest));
+    }
+
+    public function testHandleWillProxyToComposedDelegate()
+    {
+        $originalRequest = $this->prophesize(ServerRequestInterface::class)->reveal();
+
+        $delegate = function ($request, $response) use ($originalRequest) {
+            Assert::assertSame($originalRequest, $request);
+            Assert::assertSame($this->response, $response);
+            return $response;
+        };
+
+        $decorator = new CallableDelegateDecorator($delegate, $this->response);
+
+        $this->assertSame($this->response, $decorator->handle($originalRequest));
+    }
+
+    public function testNextWillProxyToComposedDelegateUsingNonServerRequest()
+    {
+        $originalRequest = $this->prophesize(RequestInterface::class)->reveal();
+
+        $delegate = function ($request, $response) use ($originalRequest) {
+            Assert::assertSame($originalRequest, $request);
+            Assert::assertSame($this->response, $response);
+            return $response;
+        };
+
+        $decorator = new CallableDelegateDecorator($delegate, $this->response);
+
+        $this->assertSame($this->response, $decorator->next($originalRequest));
+    }
+
+    public function testNextWillProxyToComposedDelegateUsingServerRequest()
+    {
+        $originalRequest = $this->prophesize(ServerRequestInterface::class)->reveal();
+
+        $delegate = function ($request, $response) use ($originalRequest) {
+            Assert::assertSame($originalRequest, $request);
+            Assert::assertSame($this->response, $response);
+            return $response;
+        };
+
+        $decorator = new CallableDelegateDecorator($delegate, $this->response);
+
+        $this->assertSame($this->response, $decorator->next($originalRequest));
+    }
+}

--- a/test/Middleware/CallableMiddlewareDecoratorTest.php
+++ b/test/Middleware/CallableMiddlewareDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Middleware/CallableMiddlewareDecoratorTest.php
+++ b/test/Middleware/CallableMiddlewareDecoratorTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Stratigility\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Zend\Stratigility\Exception;
+use Zend\Stratigility\Middleware\CallableMiddlewareDecorator;
+
+class CallableMiddlewareDecoratorTest extends TestCase
+{
+    public function testCallableMiddlewareThatDoesNotProduceAResponseRaisesAnException()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $handler = $this->prophesize(RequestHandlerInterface::class)->reveal();
+
+        $middleware = function ($request, $handler) {
+            return 'foo';
+        };
+
+        $decorator = new CallableMiddlewareDecorator($middleware);
+
+        $this->expectException(Exception\MissingResponseException::class);
+        $this->expectExceptionMessage('failed to produce a response');
+        $decorator->process($request, $handler);
+    }
+
+    public function testCallableMiddlewareReturningAResponseSucceedsProcessCall()
+    {
+        $request  = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $handler  = $this->prophesize(RequestHandlerInterface::class)->reveal();
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $middleware = function ($request, $handler) use ($response) {
+            return $response;
+        };
+
+        $decorator = new CallableMiddlewareDecorator($middleware);
+
+        $this->assertSame($response, $decorator->process($request, $handler));
+    }
+}

--- a/test/Middleware/DoublePassMiddlewareDecoratorTest.php
+++ b/test/Middleware/DoublePassMiddlewareDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Middleware/DoublePassMiddlewareDecoratorTest.php
+++ b/test/Middleware/DoublePassMiddlewareDecoratorTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Stratigility\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Zend\Diactoros\Response;
+use Zend\Stratigility\Exception;
+use Zend\Stratigility\Middleware\DoublePassMiddlewareDecorator;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+class DoublePassMiddlewareDecoratorTest extends TestCase
+{
+    public function testCallableMiddlewareThatDoesNotProduceAResponseRaisesAnException()
+    {
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $request = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $handler = $this->prophesize(RequestHandlerInterface::class)->reveal();
+
+        $middleware = function ($request, $response, $next) {
+            return 'foo';
+        };
+
+        $decorator = new DoublePassMiddlewareDecorator($middleware, $response);
+
+        $this->expectException(Exception\MissingResponseException::class);
+        $this->expectExceptionMessage('failed to produce a response');
+        $decorator->process($request, $handler);
+    }
+
+    public function testCallableMiddlewareReturningAResponseSucceedsProcessCall()
+    {
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $request  = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $handler  = $this->prophesize(RequestHandlerInterface::class)->reveal();
+
+        $middleware = function ($request, $response, $next) {
+            return $response;
+        };
+
+        $decorator = new DoublePassMiddlewareDecorator($middleware, $response);
+
+        $this->assertSame($response, $decorator->process($request, $handler));
+    }
+
+    public function testCallableMiddlewareCanDelegateViaHandler()
+    {
+        $response = $this->prophesize(ResponseInterface::class);
+        $request  = $this->prophesize(ServerRequestInterface::class);
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler
+            ->{HANDLER_METHOD}(Argument::that([$request, 'reveal']))
+            ->will([$response, 'reveal']);
+
+        $middleware = function ($request, $response, $next) {
+            return $next($request, $response);
+        };
+
+        $decorator = new DoublePassMiddlewareDecorator($middleware, $response->reveal());
+
+        $this->assertSame(
+            $response->reveal(),
+            $decorator->process($request->reveal(), $handler->reveal())
+        );
+    }
+
+    public function testDecoratorCreatesAResponsePrototypeIfNoneIsProvided()
+    {
+        $request  = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $handler  = $this->prophesize(RequestHandlerInterface::class)->reveal();
+
+        $middleware = function ($request, $response, $next) {
+            return $response;
+        };
+
+        $decorator = new DoublePassMiddlewareDecorator($middleware);
+
+        $response = $decorator->process($request, $handler);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
+    }
+}

--- a/test/Middleware/PathMiddlewareDecoratorIntegrationTest.php
+++ b/test/Middleware/PathMiddlewareDecoratorIntegrationTest.php
@@ -82,9 +82,11 @@ class PathMiddlewareDecoratorIntegrationTest extends TestCase
         );
     }
 
-    public function createPassThroughMiddleware(
-        callable $requestAssertion
-    ) : MiddlewareInterface {
+    /**
+     * @return MiddlewareInterface
+     */
+    public function createPassThroughMiddleware(callable $requestAssertion)
+    {
         $middleware = $this->prophesize(MiddlewareInterface::class);
         $middleware
             ->process(
@@ -99,7 +101,10 @@ class PathMiddlewareDecoratorIntegrationTest extends TestCase
         return $middleware->reveal();
     }
 
-    public function createNestedPipeline(ServerRequestInterface $originalRequest) : MiddlewareInterface
+    /**
+     * @return MiddlewareInterface
+     */
+    public function createNestedPipeline(ServerRequestInterface $originalRequest)
     {
         $pipeline = new MiddlewarePipe();
 

--- a/test/Middleware/PathMiddlewareDecoratorIntegrationTest.php
+++ b/test/Middleware/PathMiddlewareDecoratorIntegrationTest.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as MiddlewareInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Uri;

--- a/test/Middleware/PathMiddlewareDecoratorIntegrationTest.php
+++ b/test/Middleware/PathMiddlewareDecoratorIntegrationTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Stratigility\Middleware;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as MiddlewareInterface;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\Uri;
+use Zend\Stratigility\MiddlewarePipe;
+use Zend\Stratigility\Middleware\PathMiddlewareDecorator;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+class PathMiddlewareDecoratorIntegrationTest extends TestCase
+{
+    public function testPipelineComposingPathDecoratedMiddlewareExecutesAsExpected()
+    {
+        $uri = (new Uri)->withPath('/foo/bar/baz');
+        $request = (new ServerRequest())->withUri($uri);
+        $response = new Response();
+
+        $pipeline = new MiddlewarePipe();
+
+        $first = $this->createPassThroughMiddleware(function ($receivedRequest) use ($request) {
+            Assert::assertSame(
+                $receivedRequest,
+                $request,
+                'First middleware did not receive original request, but should have'
+            );
+            return $request;
+        });
+        $second = new PathMiddlewareDecorator('/foo', $this->createNestedPipeline($request));
+        $last = $this->createPassThroughMiddleware(function ($receivedRequest) use ($request) {
+            Assert::assertNotSame(
+                $receivedRequest,
+                $request,
+                'Last middleware received original request, but should not have'
+            );
+
+            $originalUri = $request->getUri();
+            $receivedUri = $receivedRequest->getUri();
+
+            Assert::assertNotSame(
+                $receivedUri,
+                $originalUri,
+                'Last middleware received original URI instance, but should not have'
+            );
+
+            Assert::assertSame(
+                $receivedUri->getPath(),
+                $originalUri->getPath(),
+                'Last middleware received different URI path thatn original, but should not have'
+            );
+
+            return $receivedRequest;
+        });
+
+        $pipeline->pipe($first);
+        $pipeline->pipe($second);
+        $pipeline->pipe($last);
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler
+            ->{HANDLER_METHOD}($request)
+            ->willReturn($response);
+
+        $this->assertSame(
+            $response,
+            $pipeline->process($request, $handler->reveal())
+        );
+    }
+
+    public function createPassThroughMiddleware(
+        callable $requestAssertion
+    ) : MiddlewareInterface {
+        $middleware = $this->prophesize(MiddlewareInterface::class);
+        $middleware
+            ->process(
+                Argument::that($requestAssertion),
+                Argument::type(RequestHandlerInterface::class)
+            )
+            ->will(function ($args) {
+                $request = $args[0];
+                $next = $args[1];
+                return $next->{HANDLER_METHOD}($request);
+            });
+        return $middleware->reveal();
+    }
+
+    public function createNestedPipeline(ServerRequestInterface $originalRequest) : MiddlewareInterface
+    {
+        $pipeline = new MiddlewarePipe();
+
+        $barMiddleware = $this->prophesize(MiddlewareInterface::class);
+        $barMiddleware
+            ->process(
+                Argument::that(function ($request) use ($originalRequest) {
+                    Assert::assertNotSame(
+                        $originalRequest,
+                        $request,
+                        'Decorated middleware received original request, but should not have'
+                    );
+                    $path = $request->getUri()->getPath();
+                    Assert::assertSame(
+                        '/baz',
+                        $path,
+                        'Decorated middleware expected path "/baz"; received ' . $path
+                    );
+                    return $request;
+                }),
+                Argument::type(RequestHandlerInterface::class)
+            )
+            ->will(function ($args) {
+                $request = $args[0];
+                $next = $args[1];
+                return $next->{HANDLER_METHOD}($request);
+            });
+        $decorated = new PathMiddlewareDecorator('/bar', $barMiddleware->reveal());
+
+        $normal = $this->prophesize(MiddlewareInterface::class);
+        $normal
+            ->process(
+                Argument::that(function ($request) use ($originalRequest) {
+                    Assert::assertNotSame(
+                        $originalRequest,
+                        $request,
+                        'Decorated middleware received original request, but should not have'
+                    );
+                    $path = $request->getUri()->getPath();
+                    Assert::assertSame(
+                        '/bar/baz',
+                        $path,
+                        'Decorated middleware expected path "/bar/baz"; received ' . $path
+                    );
+                    return $request;
+                }),
+                Argument::type(RequestHandlerInterface::class)
+            )
+            ->will(function ($args) {
+                $request = $args[0];
+                $next = $args[1];
+                return $next->{HANDLER_METHOD}($request);
+            });
+
+        $pipeline->pipe($decorated);
+        $pipeline->pipe($normal->reveal());
+
+        return $pipeline;
+    }
+}

--- a/test/Middleware/PathMiddlewareDecoratorTest.php
+++ b/test/Middleware/PathMiddlewareDecoratorTest.php
@@ -1,0 +1,398 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Stratigility\Middleware;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\Uri;
+use Zend\Stratigility\Middleware\PathMiddlewareDecorator;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+class PathMiddlewareDecoratorTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->uri = $this->prophesize(UriInterface::class);
+        $this->request = $this->prophesize(ServerRequestInterface::class);
+        $this->response = $this->prophesize(ResponseInterface::class);
+        $this->handler = $this->prophesize(RequestHandlerInterface::class);
+        $this->toDecorate = $this->prophesize(MiddlewareInterface::class);
+    }
+
+    public function testImplementsMiddlewareInterface()
+    {
+        $middleware = new PathMiddlewareDecorator('/foo', $this->toDecorate->reveal());
+        $this->assertInstanceOf(MiddlewareInterface::class, $middleware);
+    }
+
+    public function testComposesMiddlewarePassedToConstructor()
+    {
+        $toDecorate = $this->prophesize(MiddlewareInterface::class)->reveal();
+        $middleware = new PathMiddlewareDecorator('/foo', $toDecorate);
+        $this->assertAttributeSame($toDecorate, 'middleware', $middleware);
+    }
+
+    public function testComposesPathPrefixPassedToConstructor()
+    {
+        $middleware = new PathMiddlewareDecorator('/foo', $this->toDecorate->reveal());
+        $this->assertAttributeSame('/foo', 'prefix', $middleware);
+    }
+
+    public function testEmptyPathPrefixBecomesSingleSlash()
+    {
+        $middleware = new PathMiddlewareDecorator('', $this->toDecorate->reveal());
+        $this->assertAttributeSame('/', 'prefix', $middleware);
+    }
+
+    public function testTrailingSlashIsStrippedFromPathPrefix()
+    {
+        $middleware = new PathMiddlewareDecorator('/foo/', $this->toDecorate->reveal());
+        $this->assertAttributeSame('/foo', 'prefix', $middleware);
+    }
+
+    public function testAddsLeadingSlashWhenMissingFromPathPrefix()
+    {
+        $middleware = new PathMiddlewareDecorator('foo', $this->toDecorate->reveal());
+        $this->assertAttributeSame('/foo', 'prefix', $middleware);
+    }
+
+    public function testDelegatesOriginalRequestToHandlerIfRequestPathIsShorterThanDecoratorPrefix()
+    {
+        $this->uri
+            ->getPath()
+            ->willReturn('/f');
+        $this->request
+            ->getUri()
+            ->will([$this->uri, 'reveal']);
+        $this->handler
+            ->{HANDLER_METHOD}(Argument::that([$this->request, 'reveal']))
+            ->will([$this->response, 'reveal']);
+
+        $this->toDecorate->process(Argument::any())->shouldNotBeCalled();
+
+        $middleware = new PathMiddlewareDecorator('/foo', $this->toDecorate->reveal());
+
+        $this->assertSame(
+            $this->response->reveal(),
+            $middleware->process($this->request->reveal(), $this->handler->reveal())
+        );
+    }
+
+    public function testDelegatesOriginalRequestToHandlerIfRequestPathIsDoesNotMatchDecoratorPath()
+    {
+        $this->uri
+            ->getPath()
+            ->willReturn('/bar');
+        $this->request
+            ->getUri()
+            ->will([$this->uri, 'reveal']);
+        $this->handler
+            ->{HANDLER_METHOD}(Argument::that([$this->request, 'reveal']))
+            ->will([$this->response, 'reveal']);
+
+        $this->toDecorate->process(Argument::any())->shouldNotBeCalled();
+
+        $middleware = new PathMiddlewareDecorator('/foo', $this->toDecorate->reveal());
+    }
+
+    public function testDelegatesOrignalRequestToHandlerIfRequestDoesNotMatchPrefixAtABoundary()
+    {
+        // e.g., if route is "/foo", but path is "/foobar", no match
+        $uri = (new Uri())->withPath('/foobar');
+        $request = (new ServerRequest())->withUri($uri);
+        $response = new Response();
+
+        $middleware = $this->prophesize(MiddlewareInterface::class);
+        $middleware->process(Argument::any(), Argument::any())->shouldNotBeCalled();
+
+        $decorator = new PathMiddlewareDecorator('/foo', $middleware->reveal());
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->{HANDLER_METHOD}($request)->willReturn($response);
+
+        $this->assertSame(
+            $response,
+            $decorator->process($request, $handler->reveal())
+        );
+    }
+
+    public function nestedPathCombinations()
+    {
+        return [
+            // name                      => [$prefix, $nestPrefix, $uriPath,      $expectsHeader ]
+            'empty-bare-bare'            => ['',       'foo',    '/foo',          true],
+            'empty-bare-bareplus'        => ['',       'foo',    '/foobar',       false],
+            'empty-bare-tail'            => ['',       'foo',    '/foo/',         true],
+            'empty-bare-tailplus'        => ['',       'foo',    '/foo/bar',      true],
+            'empty-tail-bare'            => ['',       'foo/',   '/foo',          true],
+            'empty-tail-bareplus'        => ['',       'foo/',   '/foobar',       false],
+            'empty-tail-tail'            => ['',       'foo/',   '/foo/',         true],
+            'empty-tail-tailplus'        => ['',       'foo/',   '/foo/bar',      true],
+            'empty-prefix-bare'          => ['',       '/foo',   '/foo',          true],
+            'empty-prefix-bareplus'      => ['',       '/foo',   '/foobar',       false],
+            'empty-prefix-tail'          => ['',       '/foo',   '/foo/',         true],
+            'empty-prefix-tailplus'      => ['',       '/foo',   '/foo/bar',      true],
+            'empty-surround-bare'        => ['',       '/foo/',  '/foo',          true],
+            'empty-surround-bareplus'    => ['',       '/foo/',  '/foobar',       false],
+            'empty-surround-tail'        => ['',       '/foo/',  '/foo/',         true],
+            'empty-surround-tailplus'    => ['',       '/foo/',  '/foo/bar',      true],
+            'root-bare-bare'             => ['/',      'foo',    '/foo',          true],
+            'root-bare-bareplus'         => ['/',      'foo',    '/foobar',       false],
+            'root-bare-tail'             => ['/',      'foo',    '/foo/',         true],
+            'root-bare-tailplus'         => ['/',      'foo',    '/foo/bar',      true],
+            'root-tail-bare'             => ['/',      'foo/',   '/foo',          true],
+            'root-tail-bareplus'         => ['/',      'foo/',   '/foobar',       false],
+            'root-tail-tail'             => ['/',      'foo/',   '/foo/',         true],
+            'root-tail-tailplus'         => ['/',      'foo/',   '/foo/bar',      true],
+            'root-prefix-bare'           => ['/',      '/foo',   '/foo',          true],
+            'root-prefix-bareplus'       => ['/',      '/foo',   '/foobar',       false],
+            'root-prefix-tail'           => ['/',      '/foo',   '/foo/',         true],
+            'root-prefix-tailplus'       => ['/',      '/foo',   '/foo/bar',      true],
+            'root-surround-bare'         => ['/',      '/foo/',  '/foo',          true],
+            'root-surround-bareplus'     => ['/',      '/foo/',  '/foobar',       false],
+            'root-surround-tail'         => ['/',      '/foo/',  '/foo/',         true],
+            'root-surround-tailplus'     => ['/',      '/foo/',  '/foo/bar',      true],
+            'bare-bare-bare'             => ['foo',    'bar',    '/foo/bar',      true],
+            'bare-bare-bareplus'         => ['foo',    'bar',    '/foo/barbaz',   false],
+            'bare-bare-tail'             => ['foo',    'bar',    '/foo/bar/',     true],
+            'bare-bare-tailplus'         => ['foo',    'bar',    '/foo/bar/baz',  true],
+            'bare-tail-bare'             => ['foo',    'bar/',   '/foo/bar',      true],
+            'bare-tail-bareplus'         => ['foo',    'bar/',   '/foo/barbaz',   false],
+            'bare-tail-tail'             => ['foo',    'bar/',   '/foo/bar/',     true],
+            'bare-tail-tailplus'         => ['foo',    'bar/',   '/foo/bar/baz',  true],
+            'bare-prefix-bare'           => ['foo',    '/bar',   '/foo/bar',      true],
+            'bare-prefix-bareplus'       => ['foo',    '/bar',   '/foo/barbaz',   false],
+            'bare-prefix-tail'           => ['foo',    '/bar',   '/foo/bar/',     true],
+            'bare-prefix-tailplus'       => ['foo',    '/bar',   '/foo/bar/baz',  true],
+            'bare-surround-bare'         => ['foo',    '/bar/',  '/foo/bar',      true],
+            'bare-surround-bareplus'     => ['foo',    '/bar/',  '/foo/barbaz',   false],
+            'bare-surround-tail'         => ['foo',    '/bar/',  '/foo/bar/',     true],
+            'bare-surround-tailplus'     => ['foo',    '/bar/',  '/foo/bar/baz',  true],
+            'tail-bare-bare'             => ['foo/',   'bar',    '/foo/bar',      true],
+            'tail-bare-bareplus'         => ['foo/',   'bar',    '/foo/barbaz',   false],
+            'tail-bare-tail'             => ['foo/',   'bar',    '/foo/bar/',     true],
+            'tail-bare-tailplus'         => ['foo/',   'bar',    '/foo/bar/baz',  true],
+            'tail-tail-bare'             => ['foo/',   'bar/',   '/foo/bar',      true],
+            'tail-tail-bareplus'         => ['foo/',   'bar/',   '/foo/barbaz',   false],
+            'tail-tail-tail'             => ['foo/',   'bar/',   '/foo/bar/',     true],
+            'tail-tail-tailplus'         => ['foo/',   'bar/',   '/foo/bar/baz',  true],
+            'tail-prefix-bare'           => ['foo/',   '/bar',   '/foo/bar',      true],
+            'tail-prefix-bareplus'       => ['foo/',   '/bar',   '/foo/barbaz',   false],
+            'tail-prefix-tail'           => ['foo/',   '/bar',   '/foo/bar/',     true],
+            'tail-prefix-tailplus'       => ['foo/',   '/bar',   '/foo/bar/baz',  true],
+            'tail-surround-bare'         => ['foo/',   '/bar/',  '/foo/bar',      true],
+            'tail-surround-bareplus'     => ['foo/',   '/bar/',  '/foo/barbaz',   false],
+            'tail-surround-tail'         => ['foo/',   '/bar/',  '/foo/bar/',     true],
+            'tail-surround-tailplus'     => ['foo/',   '/bar/',  '/foo/bar/baz',  true],
+            'prefix-bare-bare'           => ['/foo',   'bar',    '/foo/bar',      true],
+            'prefix-bare-bareplus'       => ['/foo',   'bar',    '/foo/barbaz',   false],
+            'prefix-bare-tail'           => ['/foo',   'bar',    '/foo/bar/',     true],
+            'prefix-bare-tailplus'       => ['/foo',   'bar',    '/foo/bar/baz',  true],
+            'prefix-tail-bare'           => ['/foo',   'bar/',   '/foo/bar',      true],
+            'prefix-tail-bareplus'       => ['/foo',   'bar/',   '/foo/barbaz',   false],
+            'prefix-tail-tail'           => ['/foo',   'bar/',   '/foo/bar/',     true],
+            'prefix-tail-tailplus'       => ['/foo',   'bar/',   '/foo/bar/baz',  true],
+            'prefix-prefix-bare'         => ['/foo',   '/bar',   '/foo/bar',      true],
+            'prefix-prefix-bareplus'     => ['/foo',   '/bar',   '/foo/barbaz',   false],
+            'prefix-prefix-tail'         => ['/foo',   '/bar',   '/foo/bar/',     true],
+            'prefix-prefix-tailplus'     => ['/foo',   '/bar',   '/foo/bar/baz',  true],
+            'prefix-surround-bare'       => ['/foo',   '/bar/',  '/foo/bar',      true],
+            'prefix-surround-bareplus'   => ['/foo',   '/bar/',  '/foo/barbaz',   false],
+            'prefix-surround-tail'       => ['/foo',   '/bar/',  '/foo/bar/',     true],
+            'prefix-surround-tailplus'   => ['/foo',   '/bar/',  '/foo/bar/baz',  true],
+            'surround-bare-bare'         => ['/foo/',  'bar',    '/foo/bar',      true],
+            'surround-bare-bareplus'     => ['/foo/',  'bar',    '/foo/barbaz',   false],
+            'surround-bare-tail'         => ['/foo/',  'bar',    '/foo/bar/',     true],
+            'surround-bare-tailplus'     => ['/foo/',  'bar',    '/foo/bar/baz',  true],
+            'surround-tail-bare'         => ['/foo/',  'bar/',   '/foo/bar',      true],
+            'surround-tail-bareplus'     => ['/foo/',  'bar/',   '/foo/barbaz',   false],
+            'surround-tail-tail'         => ['/foo/',  'bar/',   '/foo/bar/',     true],
+            'surround-tail-tailplus'     => ['/foo/',  'bar/',   '/foo/bar/baz',  true],
+            'surround-prefix-bare'       => ['/foo/',  '/bar',   '/foo/bar',      true],
+            'surround-prefix-bareplus'   => ['/foo/',  '/bar',   '/foo/barbaz',   false],
+            'surround-prefix-tail'       => ['/foo/',  '/bar',   '/foo/bar/',     true],
+            'surround-prefix-tailplus'   => ['/foo/',  '/bar',   '/foo/bar/baz',  true],
+            'surround-surround-bare'     => ['/foo/',  '/bar/',  '/foo/bar',      true],
+            'surround-surround-bareplus' => ['/foo/',  '/bar/',  '/foo/barbaz',   false],
+            'surround-surround-tail'     => ['/foo/',  '/bar/',  '/foo/bar/',     true],
+            'surround-surround-tailplus' => ['/foo/',  '/bar/',  '/foo/bar/baz',  true],
+        ];
+    }
+
+    /**
+     * @dataProvider nestedPathCombinations
+     */
+    public function testNestedMiddlewareOnlyMatchesAtPathBoundaries(
+        string $prefix,
+        string $nestPrefix,
+        string $uriPath,
+        bool $expectsHeader
+    ) {
+        $finalHandler = $this->prophesize(RequestHandlerInterface::class);
+        $finalHandler->{HANDLER_METHOD}(Argument::any())->willReturn(new Response());
+
+        $nested = new PathMiddlewareDecorator($nestPrefix, new class () implements MiddlewareInterface {
+            public function process(
+                ServerRequestInterface $request,
+                RequestHandlerInterface $handler
+            ) : ResponseInterface {
+                return (new Response())->withHeader('X-Found', 'true');
+            }
+        });
+
+        $topLevel = new PathMiddlewareDecorator($prefix, new class ($nested) implements MiddlewareInterface {
+            private $middleware;
+
+            public function __construct(MiddlewareInterface $middleware)
+            {
+                $this->middleware = $middleware;
+            }
+
+            public function process(
+                ServerRequestInterface $request,
+                RequestHandlerInterface $handler
+            ) : ResponseInterface {
+                return $this->middleware->process($request, $handler);
+            }
+        });
+
+        $uri = (new Uri())->withPath($uriPath);
+        $request = (new ServerRequest())->withUri($uri);
+
+        $response = $topLevel->process($request, $finalHandler->reveal());
+
+        $this->assertSame(
+            $expectsHeader,
+            $response->hasHeader('X-Found'),
+            sprintf(
+                'Failed with full path %s against top-level prefix "%s" and nested prefix "%s"; expected %s',
+                $uriPath,
+                $prefix,
+                $nestPrefix,
+                var_export($expectsHeader, true)
+            )
+        );
+    }
+
+    public function rootPathsProvider()
+    {
+        return [
+            'empty' => [''],
+            'root'  => ['/'],
+        ];
+    }
+
+    /**
+     * @group matching
+     * @dataProvider rootPathsProvider
+     *
+     * @param string $path
+     */
+    public function testTreatsBothSlashAndEmptyPathAsTheRootPath($path)
+    {
+        $finalHandler = $this->prophesize(RequestHandlerInterface::class);
+        $finalHandler->{HANDLER_METHOD}(Argument::any())->willReturn(new Response());
+
+        $middleware = new PathMiddlewareDecorator($path, new class () implements MiddlewareInterface {
+            public function process(ServerRequestInterface $req, RequestHandlerInterface $handler) : ResponseInterface
+            {
+                $res = new Response();
+                return $res->withHeader('X-Found', 'true');
+            }
+        });
+        $uri     = (new Uri())->withPath($path);
+        $request = (new ServerRequest)->withUri($uri);
+
+        $response = $middleware->process($request, $finalHandler->reveal());
+        $this->assertTrue($response->hasHeader('x-found'));
+    }
+
+    public function testRequestPathPassedToDecoratedMiddlewareTrimsPathPrefix()
+    {
+        $finalHandler = $this->prophesize(RequestHandlerInterface::class);
+        $finalHandler->{HANDLER_METHOD}(Argument::any())->willReturn(new Response());
+
+        $request  = new ServerRequest([], [], 'http://local.example.com/foo/bar', 'GET', 'php://memory');
+
+        $middleware = $this->prophesize(MiddlewareInterface::class);
+        $middleware
+            ->process(
+                Argument::that(function (ServerRequestInterface $req) {
+                    Assert::assertSame('/bar', $req->getUri()->getPath());
+
+                    return true;
+                }),
+                Argument::any()
+            )
+            ->willReturn(new Response())
+            ->shouldBeCalledTimes(1);
+
+        $decorator = new PathMiddlewareDecorator('/foo', $middleware->reveal());
+        $decorator->process($request, $finalHandler->reveal());
+    }
+
+    public function testInvocationOfHandlerByDecoratedMiddlewareWillInvokeWithOriginalRequestPath()
+    {
+        $request = new ServerRequest([], [], 'http://local.example.com/test', 'GET', 'php://memory');
+        $expectedResponse = new Response();
+
+        $finalHandler = $this->prophesize(RequestHandlerInterface::class);
+        $finalHandler
+            ->{HANDLER_METHOD}(Argument::that(function ($received) use ($request) {
+                Assert::assertNotSame(
+                    $request,
+                    $received,
+                    'Final handler received same request, and should not have'
+                );
+
+                Assert::assertSame(
+                    $request->getUri()->getPath(),
+                    $received->getUri()->getPath(),
+                    'Final handler received request with different path'
+                );
+
+                return $received;
+            }))
+            ->willReturn($expectedResponse);
+
+        $segregatedMiddleware = $this->prophesize(MiddlewareInterface::class);
+        $segregatedMiddleware
+            ->process(
+                Argument::that(function ($received) use ($request) {
+                    Assert::assertNotSame(
+                        $request,
+                        $received,
+                        'Segregated middleware received same request as decorator, but should not have'
+                    );
+                    return $received;
+                }),
+                Argument::type(RequestHandlerInterface::class)
+            )
+            ->will(function ($args) {
+                $request = $args[0];
+                $next = $args[1];
+                return $next->{HANDLER_METHOD}($request);
+            });
+
+        $decoratedMiddleware = new PathMiddlewareDecorator('/test', $segregatedMiddleware->reveal());
+
+        $this->assertSame(
+            $expectedResponse,
+            $decoratedMiddleware->process($request, $finalHandler->reveal())
+        );
+    }
+}

--- a/test/Middleware/TestAsset/DecoratorMiddleware.php
+++ b/test/Middleware/TestAsset/DecoratorMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Middleware/TestAsset/DecoratorMiddleware.php
+++ b/test/Middleware/TestAsset/DecoratorMiddleware.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Stratigility\Middleware\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+
+class DecoratorMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var MiddlewareInterface
+     */
+    private $middleware;
+
+    public function __construct(MiddlewareInterface $middleware)
+    {
+        $this->middleware = $middleware;
+    }
+
+    /**
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler)
+    {
+        return $this->middleware->process($request, $handler);
+    }
+}

--- a/test/Middleware/TestAsset/XFoundMiddleware.php
+++ b/test/Middleware/TestAsset/XFoundMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Middleware/TestAsset/XFoundMiddleware.php
+++ b/test/Middleware/TestAsset/XFoundMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Stratigility\Middleware\TestAsset;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use Zend\Diactoros\Response;
+
+class XFoundMiddleware implements MiddlewareInterface
+{
+    /**
+     * @return Response
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler)
+    {
+        return (new Response())->withHeader('X-Found', 'true');
+    }
+}

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -21,6 +21,7 @@ use Zend\Diactoros\Uri;
 use Zend\Stratigility\Exception\InvalidMiddlewareException;
 use Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper;
 use Zend\Stratigility\Middleware\CallableMiddlewareWrapper;
+use Zend\Stratigility\Middleware\PathMiddlewareDecorator;
 use Zend\Stratigility\MiddlewarePipe;
 use Zend\Stratigility\NoopFinalHandler;
 
@@ -66,6 +67,23 @@ class MiddlewarePipeTest extends TestCase
     {
         $this->expectException(InvalidMiddlewareException::class);
         $this->middleware->pipe('/foo', $handler);
+    }
+
+    public function testPipeTriggersDeprecationErrorWhenNonEmptyPathProvidedWithoutPathMiddlewareDecorator()
+    {
+        $error = false;
+        set_error_handler(function ($errno, $errmessage) use (&$error) {
+            $error = (object) [
+                'type'    => $errno,
+                'message' => $errmessage,
+            ];
+        }, E_USER_DEPRECATED);
+        $this->middleware->pipe('/foo', $this->prophesize(ServerMiddlewareInterface::class)->reveal());
+        restore_error_handler();
+
+        $this->assertNotSame(false, $error);
+        $this->assertSame(E_USER_DEPRECATED, $error->type);
+        $this->assertContains(PathMiddlewareDecorator::class, $error->message);
     }
 
     public function testHandleInvokesUntilFirstHandlerThatDoesNotCallNext()
@@ -146,40 +164,6 @@ class MiddlewarePipeTest extends TestCase
         ], 1));
     }
 
-    public function testSlashShouldNotBeAppendedInChildMiddlewareWhenLayerDoesNotIncludeIt()
-    {
-        $this->middleware->pipe('/admin', function ($req, $res, $next) {
-            return $next($req, $res);
-        });
-
-        $this->middleware->pipe(function ($req, $res, $next) {
-            $res->getBody()->write($req->getUri()->getPath());
-            return $res;
-        });
-
-        $request = new Request([], [], 'http://local.example.com/admin', 'GET', 'php://memory');
-        $result  = $this->middleware->__invoke($request, $this->response, $this->createFinalHandler());
-        $body    = (string) $result->getBody();
-        $this->assertSame('/admin', $body);
-    }
-
-    public function testSlashShouldBeAppendedInChildMiddlewareWhenRequestUriIncludesIt()
-    {
-        $this->middleware->pipe('/admin', function ($req, $res, $next) {
-            return $next($req, $res);
-        });
-
-        $this->middleware->pipe(function ($req, $res, $next) {
-            $res->getBody()->write($req->getUri()->getPath());
-            return $res;
-        });
-
-        $request = new Request([], [], 'http://local.example.com/admin/', 'GET', 'php://memory');
-        $result  = $this->middleware->__invoke($request, $this->response, $this->createFinalHandler());
-        $body    = (string) $result->getBody();
-        $this->assertSame('/admin/', $body);
-    }
-
     public function testNestedMiddlewareMayInvokeDoneToInvokeNextOfParent()
     {
         $childMiddleware = $this->prophesize(ServerMiddlewareInterface::class);
@@ -192,7 +176,7 @@ class MiddlewarePipeTest extends TestCase
             });
 
         $childPipeline = new MiddlewarePipe();
-        $childPipeline->pipe('/', $childMiddleware->reveal());
+        $childPipeline->pipe($childMiddleware->reveal());
 
         $outerMiddleware = $this->prophesize(ServerMiddlewareInterface::class);
         $outerMiddleware
@@ -212,7 +196,7 @@ class MiddlewarePipeTest extends TestCase
         $pipeline = $this->middleware;
         $pipeline->setResponsePrototype($this->response);
         $pipeline->pipe($outerMiddleware->reveal());
-        $pipeline->pipe('/test', $childPipeline);
+        $pipeline->pipe(new PathMiddlewareDecorator('/test', $childPipeline));
         $pipeline->pipe($innerMiddleware->reveal());
 
         $request = new Request([], [], 'http://local.example.com/test', 'GET', 'php://memory');
@@ -221,189 +205,6 @@ class MiddlewarePipeTest extends TestCase
 
         $result = $pipeline->process($request, $final->reveal());
         $this->assertSame($expected, $result);
-    }
-
-    public function testMiddlewareRequestPathMustBeTrimmedOffWithPipeRoutePath()
-    {
-        $request  = new Request([], [], 'http://local.example.com/foo/bar', 'GET', 'php://memory');
-        $executed = false;
-
-        $this->middleware->pipe('/foo', function ($req, $res, $next) use (&$executed) {
-            $this->assertEquals('/bar', $req->getUri()->getPath());
-            $executed = true;
-            return $res;
-        });
-
-        $this->middleware->__invoke($request, $this->response, $this->createFinalHandler());
-        $this->assertTrue($executed);
-    }
-
-    public function rootPaths()
-    {
-        return [
-            'empty' => [''],
-            'root'  => ['/'],
-        ];
-    }
-
-    /**
-     * @group matching
-     * @dataProvider rootPaths
-     *
-     * @param string $path
-     */
-    public function testMiddlewareTreatsBothSlashAndEmptyPathAsTheRootPath($path)
-    {
-        $middleware = $this->middleware;
-        $middleware->pipe($path, function ($req, $res) {
-            return $res->withHeader('X-Found', 'true');
-        });
-        $uri     = (new Uri())->withPath($path);
-        $request = (new Request)->withUri($uri);
-
-        $response = $middleware($request, $this->response, $this->createFinalHandler());
-        $this->assertTrue($response->hasHeader('x-found'));
-    }
-
-    public function nestedPaths()
-    {
-        return [
-            'empty-bare-bare'            => ['',       'foo',    '/foo',          'assertTrue'],
-            'empty-bare-bareplus'        => ['',       'foo',    '/foobar',       'assertFalse'],
-            'empty-bare-tail'            => ['',       'foo',    '/foo/',         'assertTrue'],
-            'empty-bare-tailplus'        => ['',       'foo',    '/foo/bar',      'assertTrue'],
-            'empty-tail-bare'            => ['',       'foo/',   '/foo',          'assertTrue'],
-            'empty-tail-bareplus'        => ['',       'foo/',   '/foobar',       'assertFalse'],
-            'empty-tail-tail'            => ['',       'foo/',   '/foo/',         'assertTrue'],
-            'empty-tail-tailplus'        => ['',       'foo/',   '/foo/bar',      'assertTrue'],
-            'empty-prefix-bare'          => ['',       '/foo',   '/foo',          'assertTrue'],
-            'empty-prefix-bareplus'      => ['',       '/foo',   '/foobar',       'assertFalse'],
-            'empty-prefix-tail'          => ['',       '/foo',   '/foo/',         'assertTrue'],
-            'empty-prefix-tailplus'      => ['',       '/foo',   '/foo/bar',      'assertTrue'],
-            'empty-surround-bare'        => ['',       '/foo/',  '/foo',          'assertTrue'],
-            'empty-surround-bareplus'    => ['',       '/foo/',  '/foobar',       'assertFalse'],
-            'empty-surround-tail'        => ['',       '/foo/',  '/foo/',         'assertTrue'],
-            'empty-surround-tailplus'    => ['',       '/foo/',  '/foo/bar',      'assertTrue'],
-            'root-bare-bare'             => ['/',      'foo',    '/foo',          'assertTrue'],
-            'root-bare-bareplus'         => ['/',      'foo',    '/foobar',       'assertFalse'],
-            'root-bare-tail'             => ['/',      'foo',    '/foo/',         'assertTrue'],
-            'root-bare-tailplus'         => ['/',      'foo',    '/foo/bar',      'assertTrue'],
-            'root-tail-bare'             => ['/',      'foo/',   '/foo',          'assertTrue'],
-            'root-tail-bareplus'         => ['/',      'foo/',   '/foobar',       'assertFalse'],
-            'root-tail-tail'             => ['/',      'foo/',   '/foo/',         'assertTrue'],
-            'root-tail-tailplus'         => ['/',      'foo/',   '/foo/bar',      'assertTrue'],
-            'root-prefix-bare'           => ['/',      '/foo',   '/foo',          'assertTrue'],
-            'root-prefix-bareplus'       => ['/',      '/foo',   '/foobar',       'assertFalse'],
-            'root-prefix-tail'           => ['/',      '/foo',   '/foo/',         'assertTrue'],
-            'root-prefix-tailplus'       => ['/',      '/foo',   '/foo/bar',      'assertTrue'],
-            'root-surround-bare'         => ['/',      '/foo/',  '/foo',          'assertTrue'],
-            'root-surround-bareplus'     => ['/',      '/foo/',  '/foobar',       'assertFalse'],
-            'root-surround-tail'         => ['/',      '/foo/',  '/foo/',         'assertTrue'],
-            'root-surround-tailplus'     => ['/',      '/foo/',  '/foo/bar',      'assertTrue'],
-            'bare-bare-bare'             => ['foo',    'bar',    '/foo/bar',      'assertTrue'],
-            'bare-bare-bareplus'         => ['foo',    'bar',    '/foo/barbaz',   'assertFalse'],
-            'bare-bare-tail'             => ['foo',    'bar',    '/foo/bar/',     'assertTrue'],
-            'bare-bare-tailplus'         => ['foo',    'bar',    '/foo/bar/baz',  'assertTrue'],
-            'bare-tail-bare'             => ['foo',    'bar/',   '/foo/bar',      'assertTrue'],
-            'bare-tail-bareplus'         => ['foo',    'bar/',   '/foo/barbaz',   'assertFalse'],
-            'bare-tail-tail'             => ['foo',    'bar/',   '/foo/bar/',     'assertTrue'],
-            'bare-tail-tailplus'         => ['foo',    'bar/',   '/foo/bar/baz',  'assertTrue'],
-            'bare-prefix-bare'           => ['foo',    '/bar',   '/foo/bar',      'assertTrue'],
-            'bare-prefix-bareplus'       => ['foo',    '/bar',   '/foo/barbaz',   'assertFalse'],
-            'bare-prefix-tail'           => ['foo',    '/bar',   '/foo/bar/',     'assertTrue'],
-            'bare-prefix-tailplus'       => ['foo',    '/bar',   '/foo/bar/baz',  'assertTrue'],
-            'bare-surround-bare'         => ['foo',    '/bar/',  '/foo/bar',      'assertTrue'],
-            'bare-surround-bareplus'     => ['foo',    '/bar/',  '/foo/barbaz',   'assertFalse'],
-            'bare-surround-tail'         => ['foo',    '/bar/',  '/foo/bar/',     'assertTrue'],
-            'bare-surround-tailplus'     => ['foo',    '/bar/',  '/foo/bar/baz',  'assertTrue'],
-            'tail-bare-bare'             => ['foo/',   'bar',    '/foo/bar',      'assertTrue'],
-            'tail-bare-bareplus'         => ['foo/',   'bar',    '/foo/barbaz',   'assertFalse'],
-            'tail-bare-tail'             => ['foo/',   'bar',    '/foo/bar/',     'assertTrue'],
-            'tail-bare-tailplus'         => ['foo/',   'bar',    '/foo/bar/baz',  'assertTrue'],
-            'tail-tail-bare'             => ['foo/',   'bar/',   '/foo/bar',      'assertTrue'],
-            'tail-tail-bareplus'         => ['foo/',   'bar/',   '/foo/barbaz',   'assertFalse'],
-            'tail-tail-tail'             => ['foo/',   'bar/',   '/foo/bar/',     'assertTrue'],
-            'tail-tail-tailplus'         => ['foo/',   'bar/',   '/foo/bar/baz',  'assertTrue'],
-            'tail-prefix-bare'           => ['foo/',   '/bar',   '/foo/bar',      'assertTrue'],
-            'tail-prefix-bareplus'       => ['foo/',   '/bar',   '/foo/barbaz',   'assertFalse'],
-            'tail-prefix-tail'           => ['foo/',   '/bar',   '/foo/bar/',     'assertTrue'],
-            'tail-prefix-tailplus'       => ['foo/',   '/bar',   '/foo/bar/baz',  'assertTrue'],
-            'tail-surround-bare'         => ['foo/',   '/bar/',  '/foo/bar',      'assertTrue'],
-            'tail-surround-bareplus'     => ['foo/',   '/bar/',  '/foo/barbaz',   'assertFalse'],
-            'tail-surround-tail'         => ['foo/',   '/bar/',  '/foo/bar/',     'assertTrue'],
-            'tail-surround-tailplus'     => ['foo/',   '/bar/',  '/foo/bar/baz',  'assertTrue'],
-            'prefix-bare-bare'           => ['/foo',   'bar',    '/foo/bar',      'assertTrue'],
-            'prefix-bare-bareplus'       => ['/foo',   'bar',    '/foo/barbaz',   'assertFalse'],
-            'prefix-bare-tail'           => ['/foo',   'bar',    '/foo/bar/',     'assertTrue'],
-            'prefix-bare-tailplus'       => ['/foo',   'bar',    '/foo/bar/baz',  'assertTrue'],
-            'prefix-tail-bare'           => ['/foo',   'bar/',   '/foo/bar',      'assertTrue'],
-            'prefix-tail-bareplus'       => ['/foo',   'bar/',   '/foo/barbaz',   'assertFalse'],
-            'prefix-tail-tail'           => ['/foo',   'bar/',   '/foo/bar/',     'assertTrue'],
-            'prefix-tail-tailplus'       => ['/foo',   'bar/',   '/foo/bar/baz',  'assertTrue'],
-            'prefix-prefix-bare'         => ['/foo',   '/bar',   '/foo/bar',      'assertTrue'],
-            'prefix-prefix-bareplus'     => ['/foo',   '/bar',   '/foo/barbaz',   'assertFalse'],
-            'prefix-prefix-tail'         => ['/foo',   '/bar',   '/foo/bar/',     'assertTrue'],
-            'prefix-prefix-tailplus'     => ['/foo',   '/bar',   '/foo/bar/baz',  'assertTrue'],
-            'prefix-surround-bare'       => ['/foo',   '/bar/',  '/foo/bar',      'assertTrue'],
-            'prefix-surround-bareplus'   => ['/foo',   '/bar/',  '/foo/barbaz',   'assertFalse'],
-            'prefix-surround-tail'       => ['/foo',   '/bar/',  '/foo/bar/',     'assertTrue'],
-            'prefix-surround-tailplus'   => ['/foo',   '/bar/',  '/foo/bar/baz',  'assertTrue'],
-            'surround-bare-bare'         => ['/foo/',  'bar',    '/foo/bar',      'assertTrue'],
-            'surround-bare-bareplus'     => ['/foo/',  'bar',    '/foo/barbaz',   'assertFalse'],
-            'surround-bare-tail'         => ['/foo/',  'bar',    '/foo/bar/',     'assertTrue'],
-            'surround-bare-tailplus'     => ['/foo/',  'bar',    '/foo/bar/baz',  'assertTrue'],
-            'surround-tail-bare'         => ['/foo/',  'bar/',   '/foo/bar',      'assertTrue'],
-            'surround-tail-bareplus'     => ['/foo/',  'bar/',   '/foo/barbaz',   'assertFalse'],
-            'surround-tail-tail'         => ['/foo/',  'bar/',   '/foo/bar/',     'assertTrue'],
-            'surround-tail-tailplus'     => ['/foo/',  'bar/',   '/foo/bar/baz',  'assertTrue'],
-            'surround-prefix-bare'       => ['/foo/',  '/bar',   '/foo/bar',      'assertTrue'],
-            'surround-prefix-bareplus'   => ['/foo/',  '/bar',   '/foo/barbaz',   'assertFalse'],
-            'surround-prefix-tail'       => ['/foo/',  '/bar',   '/foo/bar/',     'assertTrue'],
-            'surround-prefix-tailplus'   => ['/foo/',  '/bar',   '/foo/bar/baz',  'assertTrue'],
-            'surround-surround-bare'     => ['/foo/',  '/bar/',  '/foo/bar',      'assertTrue'],
-            'surround-surround-bareplus' => ['/foo/',  '/bar/',  '/foo/barbaz',   'assertFalse'],
-            'surround-surround-tail'     => ['/foo/',  '/bar/',  '/foo/bar/',     'assertTrue'],
-            'surround-surround-tailplus' => ['/foo/',  '/bar/',  '/foo/bar/baz',  'assertTrue'],
-        ];
-    }
-
-    /**
-     * @group matching
-     * @group nesting
-     * @dataProvider nestedPaths
-     *
-     * @param string $topPath
-     * @param string $nestedPath
-     * @param string $fullPath
-     * @param string $assertion
-     */
-    public function testNestedMiddlewareMatchesOnlyAtPathBoundaries($topPath, $nestedPath, $fullPath, $assertion)
-    {
-        $middleware = $this->middleware;
-
-        $nest = new MiddlewarePipe();
-        $nest->setResponsePrototype($this->response);
-        $nest->pipe($nestedPath, function ($req, $res) use ($nestedPath) {
-            return $res->withHeader('X-Found', 'true');
-        });
-        $middleware->pipe($topPath, function ($req, $res, $next = null) use ($topPath, $nest) {
-            $result = $nest($req, $res, $next);
-            return $result;
-        });
-
-        $uri      = (new Uri())->withPath($fullPath);
-        $request  = (new Request)->withUri($uri);
-        $response = $middleware($request, $this->response, $this->createFinalHandler());
-        $this->$assertion(
-            $response->hasHeader('X-Found'),
-            sprintf(
-                "%s failed with full path %s against top pipe '%s' and nested pipe '%s'\n",
-                $assertion,
-                $fullPath,
-                $topPath,
-                $nestedPath
-            )
-        );
     }
 
     /**

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -64,18 +64,17 @@ class RouteTest extends TestCase
 
     public function testConstructorTriggersDeprecationErrorWhenNonEmptyPathProvidedWithoutPathMiddleware()
     {
-        $error = false;
-        set_error_handler(function ($errno, $errmessage) use (&$error) {
-            $error = (object) [
-                'type'    => $errno,
-                'message' => $errmessage,
-            ];
+        $error = (object) [];
+        set_error_handler(function ($errno, $errstr) use ($error) {
+            $error->type = $errno;
+            $error->message = $errstr;
         }, E_USER_DEPRECATED);
         new Route('/foo', $this->prophesize(ServerMiddlewareInterface::class)->reveal());
         restore_error_handler();
 
-        $this->assertNotSame(false, $error);
+        $this->assertObjectHasAttribute('type', $error);
         $this->assertSame(E_USER_DEPRECATED, $error->type);
+        $this->assertObjectHasAttribute('message', $error);
         $this->assertContains(PathMiddlewareDecorator::class, $error->message);
     }
 }

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -77,4 +77,29 @@ class RouteTest extends TestCase
         $this->assertObjectHasAttribute('message', $error);
         $this->assertContains(PathMiddlewareDecorator::class, $error->message);
     }
+
+    public function invalidPathArguments()
+    {
+        return [
+            'null'       => [null],
+            'true'       => [true],
+            'false'      => [false],
+            'zero'       => [0],
+            'int'        => [1],
+            'zero-float' => [0.0],
+            'float'      => [1.1],
+            'array'      => [['string']],
+            'object'     => [(object) ['string' => 'string']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidPathArguments
+     */
+    public function testConstructorRaisesExceptionIfPathIsNotAString($path)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Path must be a string');
+        new Route($path, $this->createEmptyMiddleware());
+    }
 }

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 


### PR DESCRIPTION
This patch provides a number of changes for a new minor version in order to help developers prepare for the upcoming 3.0.0 release. They include:

- Marking deprecated classes
  - `Route`
  - `InvalidMiddlewareException`
  - `InvalidRequestTypeException`
  - `CallableDelegateDecorator`
  - `CallableInteropMiddlewareWrapper`
  - `CallableMiddlewareWrapper`
  - `CallableMiddlewareWrapperFactory`
  - `NoopFinalHandler`
- Backporting classes/functions:
  - `CallableMiddlewareDecorator` and the associated `middleware()` utility function
  - `DoublePassMiddlewareDecorator` and the associated `doublePassMiddleware()` utility function
  - `PathMiddlewareDecorator` and the associated `path()` utility function
- Modifying internals:
  - Updating `MiddlewarePipe::pipe()` to:
    - trigger an `E_USER_DEPRECATED` error when two arguments are provided
    - decorate middleware in a `PathMiddlewareDecorator` instance when two arguments are provided
    - decorate PSR-15-compatible callables using `CallableMiddlewareDecorator` instances
    - decorate double-pass callables using `DoublePassMiddlewareDecorator` instances
  - Updating `Route` to:
    - decorate middleware in a `PathMiddlewareDecorator` instance when a non-root path is provided, and the middleware isn't already a decorator
  - Updating `Next` to:
    - remove path segregation, and instead only process middleware

These changes are mostly backwards compatible; the only ones that may affect users are the following:

- Callables are decorated using different classes. If an extension relied on the old decorators, they will need to be updated. Since this was considered an internal detail, I'm unsure if this will or should have much impact.
- Path segregated middleware is now decorated. Again, this should only affect extensions that were introspecting middleware in either the `MiddlewarePipe`, `Route`, or `Next` workflow. Again, I'm unsure if this will or should have much impact.

The patch removes some tests from `Next`, as they are now covered by the `PathMiddlewareDecorator` tests and new integration tests; existing behavior remains unchanged, however.

Finally, all changes are documented, with recommendations on how to prepare your application to remain compatible for version 3.