### PR TITLE
Adds redirect pages for legacy URLs

### DIFF
--- a/docs/book/api.md
+++ b/docs/book/api.md
@@ -1,0 +1,8 @@
+<noscript><meta http-equiv="refresh" content="0; url=v3/api/"></noscript>
+<script>
+  document.addEventListener("DOMContentLoaded", function (event) {
+    var uri = new URL(window.location.href);
+    uri.pathname = 'v3/api/';
+    window.location = uri.href;
+  });
+</script>

--- a/docs/book/creating-middleware.md
+++ b/docs/book/creating-middleware.md
@@ -1,0 +1,8 @@
+<noscript><meta http-equiv="refresh" content="0; url=v3/creating-middleware/"></noscript>
+<script>
+  document.addEventListener("DOMContentLoaded", function (event) {
+    var uri = new URL(window.location.href);
+    uri.pathname = 'v3/creating-middleware/';
+    window.location = uri.href;
+  });
+</script>

--- a/docs/book/error-handlers.md
+++ b/docs/book/error-handlers.md
@@ -1,0 +1,8 @@
+<noscript><meta http-equiv="refresh" content="0; url=v3/error-handlers/"></noscript>
+<script>
+  document.addEventListener("DOMContentLoaded", function (event) {
+    var uri = new URL(window.location.href);
+    uri.pathname = 'v3/error-handlers/';
+    window.location = uri.href;
+  });
+</script>

--- a/docs/book/executing-middleware.md
+++ b/docs/book/executing-middleware.md
@@ -1,0 +1,8 @@
+<noscript><meta http-equiv="refresh" content="0; url=v3/executing-middleware/"></noscript>
+<script>
+  document.addEventListener("DOMContentLoaded", function (event) {
+    var uri = new URL(window.location.href);
+    uri.pathname = 'v3/executing-middleware/';
+    window.location = uri.href;
+  });
+</script>

--- a/docs/book/install.md
+++ b/docs/book/install.md
@@ -1,0 +1,9 @@
+<noscript><meta http-equiv="refresh" content="0; url=v3/install/"></noscript>
+<script>
+  document.addEventListener("DOMContentLoaded", function (event) {
+    var uri = new URL(window.location.href);
+    uri.pathname = 'v3/install/';
+    window.location = uri.href;
+  });
+</script>
+

--- a/docs/book/middleware.md
+++ b/docs/book/middleware.md
@@ -1,0 +1,8 @@
+<noscript><meta http-equiv="refresh" content="0; url=v3/middleware/"></noscript>
+<script>
+  document.addEventListener("DOMContentLoaded", function (event) {
+    var uri = new URL(window.location.href);
+    uri.pathname = 'v3/middleware/';
+    window.location = uri.href;
+  });
+</script>

--- a/docs/book/migration.md
+++ b/docs/book/migration.md
@@ -1,0 +1,8 @@
+<noscript><meta http-equiv="refresh" content="0; url=v3/migration/"></noscript>
+<script>
+  document.addEventListener("DOMContentLoaded", function (event) {
+    var uri = new URL(window.location.href);
+    uri.pathname = 'v3/migration/';
+    window.location = uri.href;
+  });
+</script>

--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -1,0 +1,8 @@
+<noscript><meta http-equiv="refresh" content="0; url=v3/usage/"></noscript>
+<script>
+  document.addEventListener("DOMContentLoaded", function (event) {
+    var uri = new URL(window.location.href);
+    uri.pathname = 'v3/usage/';
+    window.location = uri.href;
+  });
+</script>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,15 @@ pages:
         - "Executing and composing middleware": v2/executing-middleware.md
         - "API Reference": v2/api.md
         - Migration: v2/migration.md
+    - "_hidden-legacy-page-links":
+        - "_install": install.md
+        - "_usage": usage.md
+        - "_middleware": middleware.md
+        - "_error-handlers": error-handlers.md
+        - "_creating-middleware": creating-middleware.md
+        - "_executing-middleware": executing-middleware.md
+        - "_api": api.md
+        - "_migration": migration.md
 site_name: zend-stratigility
 site_description: zend-stratigility
 repo_url: 'https://github.com/zendframework/zend-stratigility'


### PR DESCRIPTION
A new feature in the zf-mkdoc-theme allows you to mark a page or section to hide from navigation by prefixing the title with an underscore; the page content is then rendered only in the `<head>` of the document, allowing us to define meta refresh and JS redirect routines.

This patch does so for all pages in the currently released documentation, allowing the legacy URLs to now redirect to the v3 variants.