### PR TITLE
Added MiddlewarePipeInterface as abstraction layer for MiddlewarePipe

### DIFF
--- a/docs/book/v3/migration.md
+++ b/docs/book/v3/migration.md
@@ -75,6 +75,9 @@ internal logic.
 - `Next::handle()`: the method now provides a return typehint of
   `Psr\Http\Message\ResponseInterface`.
 
+- `MiddlewarePipe` class is marked now as `final` and implements new interface
+  `MiddlewarePipeInterface.`
+
 - `MiddlewarePipe::pipe()`: reduces the number of arguments to one, which now
   typehints against `Psr\Http\Server\MiddlewareInterface`. This means the method
   can no longer be used to segregate middleware by path. If you want to do that,
@@ -87,6 +90,11 @@ internal logic.
   `Psr\Http\Message\ResponseInterface`.
 
 ### Class additions
+
+- `Zend\Stratigility\MiddlewarePipeInterface` extends
+  `Psr\Http\Server\MiddlewareInterface` and `Psr\Http\Server\RequestHandlerInterface`
+  and define method `pipe(Psr\Http\Server\MiddlewareInterface $middleware) : void`.
+  It is implemented by `MiddlewarePipe`, because this is marked as `final` class.
 
 - `Zend\Stratigility\Middleware\HostMiddlewareDecorator` allows you to segregate
   middleware by a static host name. This allows executing middleware only

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -28,7 +28,7 @@ use SplQueue;
  *
  * @see https://github.com/sencha/connect
  */
-final class MiddlewarePipe implements MiddlewareInterface, RequestHandlerInterface
+final class MiddlewarePipe implements MiddlewarePipeInterface
 {
     /**
      * @var SplQueue

--- a/src/MiddlewarePipeInterface.php
+++ b/src/MiddlewarePipeInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+declare(strict_types=1);
+
+namespace Zend\Stratigility;
+
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+interface MiddlewarePipeInterface extends MiddlewareInterface, RequestHandlerInterface
+{
+    public function pipe(MiddlewareInterface $middleware) : void;
+}

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use ReflectionClass;
+use ReflectionMethod;
 use ReflectionObject;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest as Request;
@@ -188,7 +189,7 @@ class MiddlewarePipeTest extends TestCase
         $pipeline = new MiddlewarePipe();
 
         $r = new ReflectionObject($pipeline);
-        $methods = $r->getMethods(\ReflectionMethod::IS_PUBLIC);
+        $methods = $r->getMethods(ReflectionMethod::IS_PUBLIC);
         $actual = [];
         foreach ($methods as $method) {
             if (strpos($method->getName(), '__') !== 0) {
@@ -198,7 +199,7 @@ class MiddlewarePipeTest extends TestCase
         sort($actual);
 
         $interfaceReflection = new ReflectionClass(MiddlewarePipeInterface::class);
-        $interfaceMethods = $interfaceReflection->getMethods(\ReflectionMethod::IS_PUBLIC);
+        $interfaceMethods = $interfaceReflection->getMethods(ReflectionMethod::IS_PUBLIC);
         $expected = [];
         foreach ($interfaceMethods as $method) {
             $expected[] = $method->getName();

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -205,6 +205,7 @@ class MiddlewarePipeTest extends TestCase
         }
         sort($expected);
 
+        self::assertTrue($r->isFinal());
         self::assertEquals($expected, $actual);
         self::assertInstanceOf(MiddlewarePipeInterface::class, $pipeline);
     }

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -184,7 +184,7 @@ class MiddlewarePipeTest extends TestCase
         $this->assertSame($response, $pipeline->handle($this->request));
     }
 
-    public function testMiddlewarePipeIsInstanceOfMiddlewarePipeInterface()
+    public function testMiddlewarePipeOnlyImplementsMiddlewarePipeInterfaceApi()
     {
         $pipeline = new MiddlewarePipe();
 

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -14,10 +14,13 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use ReflectionClass;
+use ReflectionObject;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest as Request;
 use Zend\Stratigility\Exception;
 use Zend\Stratigility\MiddlewarePipe;
+use Zend\Stratigility\MiddlewarePipeInterface;
 
 class MiddlewarePipeTest extends TestCase
 {
@@ -178,5 +181,31 @@ class MiddlewarePipeTest extends TestCase
         $pipeline->pipe($middleware2->reveal());
 
         $this->assertSame($response, $pipeline->handle($this->request));
+    }
+
+    public function testMiddlewarePipeIsInstanceOfMiddlewarePipeInterface()
+    {
+        $pipeline = new MiddlewarePipe();
+
+        $r = new ReflectionObject($pipeline);
+        $methods = $r->getMethods(\ReflectionMethod::IS_PUBLIC);
+        $actual = [];
+        foreach ($methods as $method) {
+            if (strpos($method->getName(), '__') !== 0) {
+                $actual[] = $method->getName();
+            }
+        }
+        sort($actual);
+
+        $interfaceReflection = new ReflectionClass(MiddlewarePipeInterface::class);
+        $interfaceMethods = $interfaceReflection->getMethods(\ReflectionMethod::IS_PUBLIC);
+        $expected = [];
+        foreach ($interfaceMethods as $method) {
+            $expected[] = $method->getName();
+        }
+        sort($expected);
+
+        self::assertEquals($expected, $actual);
+        self::assertInstanceOf(MiddlewarePipeInterface::class, $pipeline);
     }
 }


### PR DESCRIPTION
`MiddlewarePipe` is a `final` class, so we need to have abstraction layer to make mocking easy

Fixes #144