### PR TITLE
Use foreach instead array_walk

### DIFF
--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -192,8 +192,8 @@ final class ErrorHandler implements MiddlewareInterface
         ServerRequestInterface $request,
         ResponseInterface $response
     ) : void {
-        array_walk($this->listeners, function ($listener) use ($error, $request, $response) {
+        foreach ($this->listeners as $listener) {
             $listener($error, $request, $response);
-        });
+        }
     }
 }


### PR DESCRIPTION
I know it's micro optimization, however - it's still optimization and also improve a little readability IMO.