### PR TITLE
Avoid strtolower host

### DIFF
--- a/src/Middleware/HostMiddlewareDecorator.php
+++ b/src/Middleware/HostMiddlewareDecorator.php
@@ -30,7 +30,7 @@ class HostMiddlewareDecorator implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
-        $host = strtolower($request->getUri()->getHost());
+        $host = $request->getUri()->getHost();
 
         if ($host !== strtolower($this->host)) {
             return $handler->handle($request);

--- a/test/Middleware/HostMiddlewareDecoratorTest.php
+++ b/test/Middleware/HostMiddlewareDecoratorTest.php
@@ -94,10 +94,8 @@ class HostMiddlewareDecoratorTest extends TestCase
     public function matchingHost() : Generator
     {
         yield ['host.foo', 'host.foo'];
-        yield ['host.FOO', 'host.foo'];
-        yield ['HOST.FOO', 'host.foo'];
         yield ['host.foo', 'HOST.FOO'];
-        yield ['Host.Foo', 'hOsT.fOO'];
+        yield ['host.foo', 'hOsT.fOO'];
     }
 
     /**


### PR DESCRIPTION
Lowercased host is defined by psr-7 design:

```php
    /**
     * Retrieve the host component of the URI.
     *
     * If no host is present, this method MUST return an empty string.
     *
     * The value returned MUST be normalized to lowercase, per RFC 3986
     * Section 3.2.2.
     *
     * @see http://tools.ietf.org/html/rfc3986#section-3.2.2
     * @return string The URI host.
     */
    public function getHost();
```