### PR TITLE
Implement `process()` method in PathRequestHandlerDecorator

### DIFF
--- a/src/Middleware/PathRequestHandlerDecorator.php
+++ b/src/Middleware/PathRequestHandlerDecorator.php
@@ -58,6 +58,15 @@ class PathRequestHandlerDecorator implements RequestHandlerInterface
      * Proxy to handle
      * {@inheritDocs}
      */
+    public function process(RequestInterface $request)
+    {
+        return $this->handle($request);
+    }
+
+    /**
+     * Proxy to handle
+     * {@inheritDocs}
+     */
     public function next(RequestInterface $request)
     {
         return $this->handle($request);


### PR DESCRIPTION
The 0.4.1 versions of http-interop define a `process()` method on the `DelegateInterface`; the method must be implemented for this polyfill to work across all versions of http-interop.