### PR TITLE
Fix PathMiddlewareDecorator so that path changes in decorated middleware are respected

### DIFF
--- a/src/Middleware/PathMiddlewareDecorator.php
+++ b/src/Middleware/PathMiddlewareDecorator.php
@@ -64,7 +64,7 @@ final class PathMiddlewareDecorator implements MiddlewareInterface
         // layer.
         return $this->middleware->process(
             $requestToProcess,
-            $this->prepareHandlerForOriginalRequest($handler, $request)
+            $this->prepareHandlerForOriginalRequest($handler)
         );
     }
 
@@ -97,27 +97,18 @@ final class PathMiddlewareDecorator implements MiddlewareInterface
         return substr($path, strlen($segment));
     }
 
-    private function prepareHandlerForOriginalRequest(
-        RequestHandlerInterface $handler,
-        ServerRequestInterface $originalRequest
-    ) : RequestHandlerInterface {
-        return new class ($handler, $originalRequest, $this->prefix) implements RequestHandlerInterface {
+    private function prepareHandlerForOriginalRequest(RequestHandlerInterface $handler) : RequestHandlerInterface
+    {
+        return new class ($handler, $this->prefix) implements RequestHandlerInterface {
             /** @var RequestHandlerInterface */
             private $handler;
-
-            /** @var ServerRequestInterface */
-            private $originalRequest;
 
             /** @var string */
             private $prefix;
 
-            public function __construct(
-                RequestHandlerInterface $handler,
-                ServerRequestInterface $originalRequest,
-                string $prefix
-            ) {
+            public function __construct(RequestHandlerInterface $handler, string $prefix)
+            {
                 $this->handler = $handler;
-                $this->originalRequest = $originalRequest;
                 $this->prefix = $prefix;
             }
 

--- a/src/Middleware/PathMiddlewareDecorator.php
+++ b/src/Middleware/PathMiddlewareDecorator.php
@@ -101,17 +101,24 @@ final class PathMiddlewareDecorator implements MiddlewareInterface
         RequestHandlerInterface $handler,
         ServerRequestInterface $originalRequest
     ) : RequestHandlerInterface {
-        return new class ($handler, $originalRequest) implements RequestHandlerInterface {
+        return new class ($handler, $originalRequest, $this->prefix) implements RequestHandlerInterface {
             /** @var RequestHandlerInterface */
             private $handler;
 
             /** @var ServerRequestInterface */
             private $originalRequest;
 
-            public function __construct(RequestHandlerInterface $handler, ServerRequestInterface $originalRequest)
-            {
+            /** @var string */
+            private $prefix;
+
+            public function __construct(
+                RequestHandlerInterface $handler,
+                ServerRequestInterface $originalRequest,
+                string $prefix
+            ) {
                 $this->handler = $handler;
                 $this->originalRequest = $originalRequest;
+                $this->prefix = $prefix;
             }
 
             /**
@@ -126,8 +133,8 @@ final class PathMiddlewareDecorator implements MiddlewareInterface
              */
             public function handle(ServerRequestInterface $request) : ResponseInterface
             {
-                $uri = $request->getUri()
-                    ->withPath($this->originalRequest->getUri()->getPath());
+                $uri = $request->getUri();
+                $uri = $uri->withPath($this->prefix . $uri->getPath());
                 return $this->handler->handle($request->withUri($uri));
             }
         };

--- a/test/Middleware/PathMiddlewareDecoratorTest.php
+++ b/test/Middleware/PathMiddlewareDecoratorTest.php
@@ -21,11 +21,11 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Uri;
-use function Zend\Stratigility\middleware;
 use Zend\Stratigility\Middleware\PathMiddlewareDecorator;
 
 use function sprintf;
 use function var_export;
+use function Zend\Stratigility\middleware;
 use function Zend\Stratigility\path;
 
 class PathMiddlewareDecoratorTest extends TestCase

--- a/test/Middleware/PathMiddlewareDecoratorTest.php
+++ b/test/Middleware/PathMiddlewareDecoratorTest.php
@@ -440,12 +440,13 @@ class PathMiddlewareDecoratorTest extends TestCase
     public function testUpdatesInPathInsideNestedMiddlewareAreRespected()
     {
         $request = new ServerRequest([], [], 'http://local.example.com/foo/bar', 'GET', 'php://memory');
-        $middleware = new PathMiddlewareDecorator('/foo', middleware(function (
+        $decoratedMiddleware = middleware(function (
             ServerRequestInterface $request,
             RequestHandlerInterface $handler
         ) {
             return $handler->handle($request->withUri(new Uri('/changed/path')));
-        }));
+        });
+        $middleware = new PathMiddlewareDecorator('/foo', $decoratedMiddleware);
 
         $handler = $this->prophesize(RequestHandlerInterface::class);
         $handler->handle(Argument::that(function (ServerRequestInterface $received) {


### PR DESCRIPTION
This pull request provides a fix for https://github.com/zendframework/zend-expressive/issues/606.

It fixes it for stratigility 3.0, but the same bug is present in stratigility 2.2. However, porting the changes should be easy.
