### PR TITLE
Fix example errors

### DIFF
--- a/docs/book/v3/middleware.md
+++ b/docs/book/v3/middleware.md
@@ -7,20 +7,18 @@ take the incoming request, perform actions based on it, and either complete the
 response or pass delegation on to the next middleware in the queue.
 
 ```php
-use Psr\Http\Server\MiddlewareInterface;
-use Psr\Http\Server\RequestHandlerInterface;
+require __DIR__ . '/vendor/autoload.php';
+
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Server;
+use Zend\Stratigility\Middleware\NotFoundHandler;
 use Zend\Stratigility\MiddlewarePipe;
-
 use function Zend\Stratigility\middleware;
 use function Zend\Stratigility\path;
 
-require __DIR__ . '/../vendor/autoload.php';
-
 $app = new MiddlewarePipe();
 
-$server = Server::createServer($app, $_SERVER, $_GET, $_POST, $_COOKIE, $_FILES);
+$server = Server::createServer([$app, 'handle'], $_SERVER, $_GET, $_POST, $_COOKIE, $_FILES);
 
 // Landing page
 $app->pipe(middleware(function ($req, $handler) {
@@ -30,6 +28,7 @@ $app->pipe(middleware(function ($req, $handler) {
 
     $response = new Response();
     $response->getBody()->write('Hello world!');
+
     return $response;
 }));
 
@@ -37,14 +36,20 @@ $app->pipe(middleware(function ($req, $handler) {
 $app->pipe(path('/foo', middleware(function ($req, $handler) {
     $response = new Response();
     $response->getBody()->write('FOO!');
+
     return $response;
 })));
 
 // 404 handler
-$app->pipe(new NotFoundHandler(new Response());
+$app->pipe(new NotFoundHandler(function () {
+    $response = new Response();
+    $response->getBody()->write('Not found!');
+
+    return $response->withStatus(404);
+}));
 
 $server->listen(function ($req, $res) {
-  return $res;
+    return $res;
 });
 ```
 

--- a/docs/book/v3/middleware.md
+++ b/docs/book/v3/middleware.md
@@ -13,6 +13,7 @@ use Zend\Diactoros\Response;
 use Zend\Diactoros\Server;
 use Zend\Stratigility\Middleware\NotFoundHandler;
 use Zend\Stratigility\MiddlewarePipe;
+
 use function Zend\Stratigility\middleware;
 use function Zend\Stratigility\path;
 


### PR DESCRIPTION
- Fix line 23 error, must be `[$app, 'handle']` instead `$app`.
- There's a typo error in line 44, `$app->pipe(new NotFoundHandler(new Response());`, lacks the last `)`. Also, an instance of `Zend\Diactoros\Response` is passed as an argument, but `NotFoundHandler` needs a `callable`, so I changed to a working example of a not simple 404 implementation.
- Fixed indentation in line 47.
- Removed unused imports.

- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
