### PR TITLE
Backport #165 to v2.2 release

### DIFF
--- a/src/Middleware/PathMiddlewareDecorator.php
+++ b/src/Middleware/PathMiddlewareDecorator.php
@@ -70,7 +70,7 @@ class PathMiddlewareDecorator implements MiddlewareInterface
         // layer.
         return $this->middleware->process(
             $requestToProcess,
-            new PathRequestHandlerDecorator($handler, $request)
+            new PathRequestHandlerDecorator($handler, $this->prefix)
         );
     }
 

--- a/src/Middleware/PathRequestHandlerDecorator.php
+++ b/src/Middleware/PathRequestHandlerDecorator.php
@@ -33,14 +33,17 @@ class PathRequestHandlerDecorator implements RequestHandlerInterface
     private $handler;
 
     /**
-     * @var ServerRequestInterface
+     * @var string
      */
-    private $originalRequest;
+    private $prefix;
 
-    public function __construct(RequestHandlerInterface $handler, ServerRequestInterface $originalRequest)
+    /**
+     * @param string $prefix
+     */
+    public function __construct(RequestHandlerInterface $handler, $prefix)
     {
         $this->handler = $handler;
-        $this->originalRequest = $originalRequest;
+        $this->prefix = $prefix;
     }
 
     /**
@@ -49,8 +52,8 @@ class PathRequestHandlerDecorator implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request)
     {
-        $uri = $request->getUri()
-            ->withPath($this->originalRequest->getUri()->getPath());
+        $uri = $request->getUri();
+        $uri = $uri->withPath($this->prefix . $uri->getPath());
         return $this->handler->{HANDLER_METHOD}($request->withUri($uri));
     }
 

--- a/test/Middleware/PathMiddlewareDecoratorTest.php
+++ b/test/Middleware/PathMiddlewareDecoratorTest.php
@@ -379,13 +379,13 @@ class PathMiddlewareDecoratorTest extends TestCase
             ServerRequestInterface $request,
             RequestHandlerInterface $handler
         ) {
-            return $handler->handle($request->withUri(new Uri('/changed/path')));
+            return $handler->{HANDLER_METHOD}($request->withUri(new Uri('/changed/path')));
         });
         $middleware = new PathMiddlewareDecorator('/foo', $decoratedMiddleware);
 
         $handler = $this->prophesize(RequestHandlerInterface::class);
         $handler
-            ->handle(Argument::that(function (ServerRequestInterface $received) {
+            ->{HANDLER_METHOD}(Argument::that(function (ServerRequestInterface $received) {
                 Assert::assertEquals('/foo/changed/path', $received->getUri()->getPath());
 
                 return $received;

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -25,6 +25,10 @@ use Zend\Stratigility\Middleware\PathMiddlewareDecorator;
 use Zend\Stratigility\Next;
 use Zend\Stratigility\Route;
 
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+use function Zend\Stratigility\middleware;
+
 class NextTest extends TestCase
 {
     protected $errorHandler;
@@ -89,18 +93,16 @@ class NextTest extends TestCase
         $cannedRequest = clone $request;
         $cannedRequest = $cannedRequest->withMethod('POST');
 
-        $route1 = new Route('/foo/bar', $this->decorateCallableMiddleware(
+        $route1 = new Route('/', $this->decorateCallableMiddleware(
             function ($req, $res, $next) use ($cannedRequest) {
                 return $next($cannedRequest, $res);
-            },
-            '/foo/bar'
+            }
         ));
-        $route2 = new Route('/foo/bar/baz', $this->decorateCallableMiddleware(
+        $route2 = new Route('/', $this->decorateCallableMiddleware(
             function ($req, $res, $next) use ($cannedRequest) {
                 $this->assertEquals($cannedRequest->getMethod(), $req->getMethod());
                 return $res;
-            },
-            '/foo/bar/baz'
+            }
         ));
 
         $this->queue->enqueue($route1);


### PR DESCRIPTION
This patch backports the fix from #165 to the 2.2 series, as the but exists in that version as well.

Essentially, previous versions allowed something like the following:

```php
new PathMiddlewareDecorator('/api', middleware(function ($request, $handler) {
    $uri = $request->getUri();
     if (! preg_match('#^/v\d+/#', $uri->getPath())) {
         $request = $request->withUri($uri->withPath('/v1' . $uri->getPath()));
     }
     return $handler->handle($request);
}));
```

In the above example, the path `/api/books` would result in a lower layer receiving `/api/v1/books`. This worked on versions prior to 2.1, but not in 2.2 or 3.0.

The patch provided here is a backport of the one in #165, and re-worked to work with PHP 5.6 and 7.0.