### PR TITLE
Fixes path truncation in PathMiddlewareDecorator to be case insensitive

### DIFF
--- a/src/Middleware/PathMiddlewareDecorator.php
+++ b/src/Middleware/PathMiddlewareDecorator.php
@@ -108,7 +108,7 @@ class PathMiddlewareDecorator implements MiddlewareInterface
      */
     private function getTruncatedPath($segment, $path)
     {
-        if ($segment === $path) {
+        if (strtolower($segment) === strtolower($path)) {
             // Decorated path and current path are the same; return empty string
             return '';
         }

--- a/test/Middleware/PathMiddlewareDecoratorTest.php
+++ b/test/Middleware/PathMiddlewareDecoratorTest.php
@@ -394,4 +394,30 @@ class PathMiddlewareDecoratorTest extends TestCase
 
         $this->assertSame($response, $middleware->process($request, $handler->reveal()));
     }
+
+    public function testProcessesMatchedPathsWithoutCaseSensitivity()
+    {
+        $finalHandler = $this->prophesize(RequestHandlerInterface::class);
+        $finalHandler->{HANDLER_METHOD}(Argument::any())->willReturn(new Response());
+
+        // Note that the path requested is ALL CAPS:
+        $request  = new ServerRequest([], [], 'http://local.example.com/MYADMIN', 'GET', 'php://memory');
+
+        $middleware = $this->prophesize(MiddlewareInterface::class);
+        $middleware
+            ->process(
+                Argument::that(function (ServerRequestInterface $req) {
+                    Assert::assertSame('', $req->getUri()->getPath());
+
+                    return true;
+                }),
+                Argument::any()
+            )
+            ->willReturn(new Response())
+            ->shouldBeCalledTimes(1);
+
+        // Note that the path to match is lowercase:
+        $decorator = new PathMiddlewareDecorator('/myadmin', $middleware->reveal());
+        $decorator->process($request, $finalHandler->reveal());
+    }
 }


### PR DESCRIPTION
In #168, we received a report indicating that path matching within `PathMiddlewareDecorator` fails if the path is the same, but using a different case.

Interestingly, we _match_ it correctly; the problem is when _preparing the truncated path_ to pass on to the decorated middleware, as it cannot identify the matched segment correctly.

This patch modifies the logic in `getTruncatedPath()` to do a case-insensitive comparison of the segment and the path in the initial condition.

This problem is likely relevant in current master as well, and will be ported to that branch on completion.

Fixes #168