### PR TITLE
Remove condition with after call `handle` in `ErrorHandler`

### DIFF
--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -141,10 +141,6 @@ final class ErrorHandler implements MiddlewareInterface
 
         try {
             $response = $handler->handle($request);
-
-            if (! $response instanceof ResponseInterface) {
-                throw new MissingResponseException('Application did not return a response');
-            }
         } catch (Throwable $e) {
             $response = $this->handleThrowable($e, $request);
         }


### PR DESCRIPTION
The `handle` method have a return type of `ResponseInterface`, so it was never be executed.
And there is no unit test to handler it.
