### PR TITLE
Reuse code in MiddlewarePipe from Next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,18 @@ details.
 
 ### Added
 
-- Nothing.
+- [#178](https://github.com/zendframework/zend-stratigility/pull/178) adds the class `Zend\Stratigility\EmptyPipelineHandler`, which raises an
+  `EmptyPipelineException` when it handles an incoming request. It's primary
+  purpose is for use in the `MiddlewarePipe` as a fallback handler during
+  `handle()` operations.
 
 ### Changed
+
+- [#178](https://github.com/zendframework/zend-stratigility/pull/178) provides some performance improvements to `MiddlewarePipe::handle()` by
+  having it create an instance of `EmptyPipelineHandler` to use as a fallback
+  handler when it calls `process()` on itself. This prevents cloning of the
+  pipeline in this scenario, which is used when it acts as an application
+  entrypoint.
 
 - [#185](https://github.com/zendframework/zend-stratigility/pull/185) removes the "final" declaration from the `ErrorHandler` class, to allow
   more easily mocking it for testing.

--- a/src/EmptyPipelineHandler.php
+++ b/src/EmptyPipelineHandler.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Stratigility;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class EmptyPipelineHandler implements RequestHandlerInterface
+{
+    private $class;
+
+    public function __construct(string $class)
+    {
+        $this->class = $class;
+    }
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        throw Exception\EmptyPipelineException::forClass($this->class);
+    }
+}

--- a/src/EmptyPipelineHandler.php
+++ b/src/EmptyPipelineHandler.php
@@ -15,14 +15,15 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final class EmptyPipelineHandler implements RequestHandlerInterface
 {
-    private $class;
+    private $className;
 
-    public function __construct(string $class)
+    public function __construct(string $className)
     {
-        $this->class = $class;
+        $this->className = $className;
     }
+
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        throw Exception\EmptyPipelineException::forClass($this->class);
+        throw Exception\EmptyPipelineException::forClass($this->className);
     }
 }

--- a/src/EmptyPipelineHandler.php
+++ b/src/EmptyPipelineHandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 
@@ -15,6 +15,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final class EmptyPipelineHandler implements RequestHandlerInterface
 {
+    /**
+     * @var string
+     */
     private $className;
 
     public function __construct(string $className)

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -69,13 +69,12 @@ final class MiddlewarePipe implements MiddlewarePipeInterface
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        if ($this->pipeline->isEmpty()) {
-            throw Exception\EmptyPipelineException::forClass(__CLASS__);
-        }
-
-        $nextHandler = clone $this;
-        $middleware = $nextHandler->pipeline->dequeue();
-        return $middleware->process($request, $nextHandler);
+        return $this->process($request, new class implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request) : ResponseInterface
+            {
+                throw Exception\EmptyPipelineException::forClass(__CLASS__);
+            }
+        });
     }
 
     /**

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -69,12 +69,7 @@ final class MiddlewarePipe implements MiddlewarePipeInterface
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        return $this->process($request, new class implements RequestHandlerInterface {
-            public function handle(ServerRequestInterface $request) : ResponseInterface
-            {
-                throw Exception\EmptyPipelineException::forClass(__CLASS__);
-            }
-        });
+        return $this->process($request, new EmptyPipelineHandler(__CLASS__));
     }
 
     /**
@@ -85,9 +80,7 @@ final class MiddlewarePipe implements MiddlewarePipeInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
-        $next = new Next($this->pipeline, $handler);
-
-        return $next->handle($request);
+        return (new Next($this->pipeline, $handler))->handle($request);
     }
 
     /**

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2015-2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 


### PR DESCRIPTION
I had refactor step by step (commit by commit) so you can reviewing this pr by commits.

By first step I remove duplication of `Next` and `MiddlewarePipe` - `Next` can be deprecated.
Then I replace SplQueue to array - IMO they are fasters however I didn't any benchmarks.
I last change I move `Next` logic into Handle method - for improved readability.