### PR TITLE
Remove "final" declaration from ErrorHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ details.
 
 ### Changed
 
-- Nothing.
+- [#185](https://github.com/zendframework/zend-stratigility/pull/185) removes the "final" declaration from the `ErrorHandler` class, to allow
+  more easily mocking it for testing.
 
 ### Deprecated
 

--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2016-2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 
@@ -68,7 +68,7 @@ use function set_error_handler;
  * Listeners are attached using the attachListener() method, and triggered
  * in the order attached.
  */
-final class ErrorHandler implements MiddlewareInterface
+class ErrorHandler implements MiddlewareInterface
 {
     /**
      * @var callable[]


### PR DESCRIPTION
Per #176, because the `ErrorHandler` adds a public method that is not in any interface, it cannot be easily mocked for testing purposes. This patch removes that declaration.

Fixes #176