### PR TITLE
Throw EmptyPipelineException if passed in continuation is invoked more than once.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ details.
 
 ### Added
 
-- Nothing.
+- [#186](https://github.com/zendframework/zend-stratigility/pull/186) adds safeguard
+  to middleware pipe Next handler, preventing it from being called multiple
+  times, which causes undefined behavior after queue of middlewares was
+  exhausted on the first pass.
 
 ### Changed
 

--- a/src/Exception/MiddlewarePipeNextHandlerAlreadyCalledException.php
+++ b/src/Exception/MiddlewarePipeNextHandlerAlreadyCalledException.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Stratigility\Exception;
+
+use BadMethodCallException;
+
+class MiddlewarePipeNextHandlerAlreadyCalledException extends BadMethodCallException implements ExceptionInterface
+{
+
+    public static function create(): self
+    {
+        return new self("Cannot invoke Next handler more than once");
+    }
+}

--- a/src/Exception/MiddlewarePipeNextHandlerAlreadyCalledException.php
+++ b/src/Exception/MiddlewarePipeNextHandlerAlreadyCalledException.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 
 namespace Zend\Stratigility\Exception;
 
-use BadMethodCallException;
+use DomainException;
 
-class MiddlewarePipeNextHandlerAlreadyCalledException extends BadMethodCallException implements ExceptionInterface
+class MiddlewarePipeNextHandlerAlreadyCalledException extends DomainException implements ExceptionInterface
 {
 
     public static function create(): self

--- a/src/Exception/MiddlewarePipeNextHandlerAlreadyCalledException.php
+++ b/src/Exception/MiddlewarePipeNextHandlerAlreadyCalledException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/MiddlewarePipeNextHandlerAlreadyCalledException.php
+++ b/src/Exception/MiddlewarePipeNextHandlerAlreadyCalledException.php
@@ -16,6 +16,6 @@ class MiddlewarePipeNextHandlerAlreadyCalledException extends DomainException im
 
     public static function create(): self
     {
-        return new self("Cannot invoke Next handler more than once");
+        return new self('Cannot invoke pipeline handler $handler->handle() more than once');
     }
 }

--- a/src/Next.php
+++ b/src/Next.php
@@ -42,7 +42,7 @@ final class Next implements RequestHandlerInterface
         $this->queue           = clone $queue;
         $this->fallbackHandler = $fallbackHandler;
         $this->queue->push(
-            new RequestHandlerMiddleware($fallbackHandler),
+            new RequestHandlerMiddleware($fallbackHandler)
         );
     }
 

--- a/src/Next.php
+++ b/src/Next.php
@@ -54,8 +54,8 @@ final class Next implements RequestHandlerInterface
         }
 
         $middleware = $this->queue->dequeue();
-        $next = clone $this;
-        $this->queue = null;
+        $next = clone $this; // deep clone is not used intentionally
+        $this->queue = null; // mark queue as processed at this nesting level
 
         return $middleware->process($request, $next);
     }

--- a/src/Next.php
+++ b/src/Next.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2015-2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 
@@ -26,7 +26,7 @@ final class Next implements RequestHandlerInterface
     private $fallbackHandler;
 
     /**
-     * @var SplQueue
+     * @var null|SplQueue
      */
     private $queue;
 

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -220,8 +220,6 @@ class NextTest extends TestCase
 
     public function testNextHandlerCannotBeInvokedTwice()
     {
-        $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
-
         $fallbackHandler = $this->prophesize(RequestHandlerInterface::class);
         $fallbackHandler
             ->handle(Argument::any())
@@ -231,13 +229,13 @@ class NextTest extends TestCase
 
         $next = new Next($this->queue, $fallbackHandler->reveal());
         $next->handle($this->request);
+
+        $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
         $next->handle($this->request);
     }
 
     public function testSecondInvocationAttemptDoesNotInvokeFinalHandler()
     {
-        $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
-
         $fallBackHandler = $this->prophesize(RequestHandlerInterface::class);
         $fallBackHandler
             ->handle(Argument::any())
@@ -248,13 +246,13 @@ class NextTest extends TestCase
 
         $next = new Next($this->queue, $fallBackHandler->reveal());
         $next->handle($this->request);
+
+        $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
         $next->handle($this->request);
     }
 
     public function testSecondInvocationAttemptDoesNotInvokeMiddleware()
     {
-        $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
-
         $fallBackHandler = $this->prophesize(RequestHandlerInterface::class);
         $fallBackHandler
             ->handle(Argument::any())
@@ -275,13 +273,13 @@ class NextTest extends TestCase
 
         $next = new Next($this->queue, $fallBackHandler->reveal());
         $next->handle($this->request);
+
+        $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
         $next->handle($this->request);
     }
 
     public function testShortCircuitingMiddlewareDoesNotEnableSecondInvocation()
     {
-        $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
-
         $fallBackHandler = $this->prophesize(RequestHandlerInterface::class);
         $fallBackHandler
             ->handle(Argument::any())
@@ -296,13 +294,13 @@ class NextTest extends TestCase
 
         $next = new Next($this->queue, $fallBackHandler->reveal());
         $next->handle($this->request);
+
+        $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
         $next->handle($this->request);
     }
 
     public function testSecondInvocationAttemptWithEmptyQueueDoesNotInvokeFinalHandler()
     {
-        $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
-
         $fallBackHandler = $this->prophesize(RequestHandlerInterface::class);
         $fallBackHandler
             ->handle(Argument::any())
@@ -312,6 +310,8 @@ class NextTest extends TestCase
         $next = new Next($this->queue, $fallBackHandler->reveal());
 
         $next->handle($this->request);
+
+        $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
         $next->handle($this->request);
     }
 }

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -223,13 +223,14 @@ class NextTest extends TestCase
         $fallBackHandler
             ->handle(Argument::any())
             ->shouldBeCalledTimes(1);
-            
+
         // Middleware calling $handler->handle() twice. The first call will empty the
         // middleware queue while the second call will raise the empty pipline exception.
         $middleware = (new class () implements MiddlewareInterface {
-            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface {
-                $handler->handle($request);
-                return $handler->handle($request);
+            public function process(ServerRequestInterface $req, RequestHandlerInterface $h): ResponseInterface
+            {
+                $h->handle($req);
+                return $h->handle($req);
             }
         });
         $this->queue->push($middleware);

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -264,7 +264,7 @@ class NextTest extends TestCase
         $middleware
             ->process(
                 Argument::type(ServerRequestInterface::class),
-                Argument::type(RequestHandlerInterface::class),
+                Argument::type(RequestHandlerInterface::class)
             )
             ->will(function (array $args): ResponseInterface {
                 return $args[1]->handle($args[0]);

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -218,7 +218,7 @@ class NextTest extends TestCase
         $this->assertSame($response, $next->handle($this->request));
     }
 
-    public function testFallBackHandlerCannotBeInvokedTwice()
+    public function testSecondInvocationDoesNotInvokeFinalHandler()
     {
         $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
 
@@ -242,7 +242,7 @@ class NextTest extends TestCase
         $next->handle($this->request);
     }
 
-    public function testMiddlewareCannotBeInvokedTwice()
+    public function testSecondInvocationDoesNotInvokeMiddleware()
     {
         $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
 
@@ -266,7 +266,7 @@ class NextTest extends TestCase
         $next->handle($this->request);
     }
 
-    public function testMiddlewareCannotBeInvokedTwiceWhenMiddlewareShortCircuitsTheProcess()
+    public function testShortCircuitingMiddlewareDoesNotEnableSecondInvocation()
     {
         $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);
 
@@ -294,7 +294,7 @@ class NextTest extends TestCase
         $next->handle($this->request);
     }
 
-    public function testFallbackHandlerCannotBeInvokedTwiceWhenMiddlewareQueueIsEmpty()
+    public function testSecondInvocationWithEmptyQueueDoesNotInvokeFinalHandler()
     {
 
         $this->expectException(MiddlewarePipeNextHandlerAlreadyCalledException::class);

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -18,13 +18,13 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use SplQueue;
+use ZendTest\Stratigility\TestAsset\DelegatingMiddleware;
+use ZendTest\Stratigility\TestAsset\ShortCircuitingMiddleware;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest as Request;
 use Zend\Diactoros\Uri;
-use Zend\Stratigility\Next;
 use Zend\Stratigility\Exception\MiddlewarePipeNextHandlerAlreadyCalledException;
-use ZendTest\Stratigility\TestAsset\ShortCircuitingMiddleware;
-use ZendTest\Stratigility\TestAsset\DelegatingMiddleware;
+use Zend\Stratigility\Next;
 
 class NextTest extends TestCase
 {

--- a/test/NextTest.php
+++ b/test/NextTest.php
@@ -286,7 +286,7 @@ class NextTest extends TestCase
         $this->queue->push(new ShortCircuitingMiddleware);
 
         // The middleware above shorcircuits (when handler is invoked first in $middleware)
-        // The middlewares below still exists in the queue (when handler is invoked again in $middleware)
+        // The middlewares below still exist in the queue (when handler is invoked again in $middleware)
         $this->queue->push(new DelegatingMiddleware);
         $this->queue->push(new DelegatingMiddleware);
 

--- a/test/TestAsset/DelegatingMiddleware.php
+++ b/test/TestAsset/DelegatingMiddleware.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace ZendTest\Stratigility\TestAsset;
 
-use Psr\Http\Server\MiddlewareInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 class DelegatingMiddleware implements MiddlewareInterface
 {

--- a/test/TestAsset/DelegatingMiddleware.php
+++ b/test/TestAsset/DelegatingMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Stratigility\TestAsset;
+
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class DelegatingMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $req, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($req);
+    }
+}

--- a/test/TestAsset/DelegatingMiddleware.php
+++ b/test/TestAsset/DelegatingMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/TestAsset/ShortCircuitingMiddleware.php
+++ b/test/TestAsset/ShortCircuitingMiddleware.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace ZendTest\Stratigility\TestAsset;
 
-use Psr\Http\Server\MiddlewareInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Response;
 
 class ShortCircuitingMiddleware implements MiddlewareInterface

--- a/test/TestAsset/ShortCircuitingMiddleware.php
+++ b/test/TestAsset/ShortCircuitingMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/TestAsset/ShortCircuitingMiddleware.php
+++ b/test/TestAsset/ShortCircuitingMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Stratigility\TestAsset;
+
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Zend\Diactoros\Response;
+
+class ShortCircuitingMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $req, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return new Response();
+    }
+}


### PR DESCRIPTION
- [x] _Are you fixing a bug?_  
       Yes
  - [x] _Detail how the bug is invoked currently._ 
          By calling the handler that is passed in the middlewares more than once.

  - [x] _Detail the original, incorrect behavior._
          The handler `Next::$fallbackHandler` is invoked more than once. The first invocation
           of $handler->handle inside a middleware drains the middleware queue in Next::queue,
           subsequent invocations of $handler->handle invoke Next::$fallbackHandler.

  - [x] _Detail the new, expected behavior._
           The handler should be allowed to be invoked only once or the behavior will be inconsistent. The first middleware
           invokes the second middleware in the pipe when calling hanlder::handle first time, 
           second time it will be invoking the handler `Next::$fallbackHandler`.

  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] _Add a regression test that demonstrates the bug, and proves the fix._
         Added the smallest failing test, and the code to pass it in NextTest.php . Didn't remove uneeded `Next::$fallbackHandler` because one of the tests checks of its existence.
  - [ ] Add a `CHANGELOG.md` entry for the fix.