### PR TITLE
Moving NotFoundHandler to Handler namespace

### DIFF
--- a/src/Handler/NotFoundHandler.php
+++ b/src/Handler/NotFoundHandler.php
@@ -17,9 +17,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 use function sprintf;
 
-/**
- * @todo Remove the `MiddlewareInterface` implementation in v4.
- */
 final class NotFoundHandler implements RequestHandlerInterface
 {
     /**

--- a/src/Handler/NotFoundHandler.php
+++ b/src/Handler/NotFoundHandler.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Stratigility\Handler;
+
+use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+use function sprintf;
+
+/**
+ * @todo Remove the `MiddlewareInterface` implementation in v4.
+ */
+final class NotFoundHandler implements RequestHandlerInterface
+{
+    /**
+     * @var callable
+     */
+    private $responseFactory;
+
+    /**
+     * @param callable $responseFactory A factory capable of returning an
+     *     empty ResponseInterface instance to update and return when returning
+     *     an 404 response.
+     */
+    public function __construct(callable $responseFactory)
+    {
+        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
+            return $responseFactory();
+        };
+    }
+
+    /**
+     * Creates and retursn a 404 response.
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        /** @var ResponseInterface $response */
+        $response = ($this->responseFactory)()
+            ->withStatus(StatusCode::STATUS_NOT_FOUND);
+        $response->getBody()->write(sprintf(
+            'Cannot %s %s',
+            $request->getMethod(),
+            (string) $request->getUri()
+        ));
+        return $response;
+    }
+}

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -9,13 +9,10 @@ declare(strict_types=1);
 
 namespace Zend\Stratigility\Middleware;
 
-use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-
-use function sprintf;
 use Zend\Stratigility\Handler\NotFoundHandler as NotFoundRequestHandler;
 
 /**

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -16,13 +16,18 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 use function sprintf;
+use Zend\Stratigility\Handler\NotFoundHandler as NotFoundRequestHandler;
 
+/**
+ * @deprecated Will be removed in v4 in favor of {@see \Zend\Stratigility\Handler\NotFoundHandler}
+ */
 final class NotFoundHandler implements MiddlewareInterface
 {
+
     /**
-     * @var callable
+     * @var NotFoundRequestHandler
      */
-    private $responseFactory;
+    private $notFoundHandler;
 
     /**
      * @param callable $responseFactory A factory capable of returning an
@@ -31,23 +36,14 @@ final class NotFoundHandler implements MiddlewareInterface
      */
     public function __construct(callable $responseFactory)
     {
-        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
-            return $responseFactory();
-        };
+        $this->notFoundHandler = new NotFoundRequestHandler($responseFactory);
     }
 
     /**
-     * Creates and returns a 404 response.
+     * Uses the {@see \Zend\Stratigility\Handler\NotFoundHandler} to create a 404 response.
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
-        $response = ($this->responseFactory)()
-            ->withStatus(StatusCode::STATUS_NOT_FOUND);
-        $response->getBody()->write(sprintf(
-            'Cannot %s %s',
-            $request->getMethod(),
-            (string) $request->getUri()
-        ));
-        return $response;
+        return $this->notFoundHandler->handle($request);
     }
 }

--- a/test/Handler/NotFoundHandlerTest.php
+++ b/test/Handler/NotFoundHandlerTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Stratigility\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Zend\Stratigility\Handler\NotFoundHandler;
+
+class NotFoundHandlerTest extends TestCase
+{
+    public function testReturnsResponseWith404StatusAndErrorMessageInBody()
+    {
+        $stream = $this->prophesize(StreamInterface::class);
+        $stream->write('Cannot POST https://example.com/foo');
+
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->withStatus(404)->will([$response, 'reveal']);
+        $response->getBody()->will([$stream, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn('POST');
+        $request->getUri()->willReturn('https://example.com/foo');
+
+        $responseFactory = function () use ($response) {
+            return $response->reveal();
+        };
+
+        $middleware = new NotFoundHandler($responseFactory);
+
+        $this->assertSame(
+            $response->reveal(),
+            $middleware->handle($request->reveal())
+        );
+    }
+}


### PR DESCRIPTION
Maybe same procedure as in #191 

As the `NotFoundHandler` is technically a `RequestHandler`, I am moving it to the `Handler` namespace instead while marking the `NotFoundHandler` in the `Middleware` namespace as deprecated.